### PR TITLE
chore: open the 1.3.0 development cycle

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,8 +103,12 @@ jobs:
               n = cur.pre[1] + 1 if cur.pre and cur.pre[0] == 'rc' else 0
               out = f'{major}.{minor}.{micro}rc{n}'
           elif bump == 'dev':
-              n = cur.dev + 1 if cur.is_devrelease else 0
-              out = f'{major}.{minor}.{micro}.dev{n}'
+              # step the dev number of a development version, otherwise open
+              # the next cycle after a release, which is a minor bump
+              if cur.is_devrelease:
+                  out = f'{major}.{minor}.{micro}.dev{cur.dev + 1}'
+              else:
+                  out = f'{major}.{minor + 1}.0.dev0'
           else:
               raise SystemExit(f'unknown bump {bump}')
           print(out)

--- a/mf6adj/version.py
+++ b/mf6adj/version.py
@@ -1,4 +1,4 @@
 # mf6adj version file automatically created using
-# update_version.py on August 03, 2026 21:53:12
+# update_version.py on August 03, 2026 17:36:12
 
-__version__ = "1.2.0"
+__version__ = "1.3.0.dev0"


### PR DESCRIPTION
Sets the version on main to `1.3.0.dev0` now that 1.2.0 is released, matching what #63 did after 1.1.0.

Also corrects the `dev` bump in the release workflow. From a released `1.2.0` it produced `1.2.0.dev0`, which sorts below the release it follows. A dev bump now steps the dev number of a development version, and opens the next minor cycle after a release.