### PR TITLE
feat(sfr): solve the reach routing with the flow equations

### DIFF
--- a/autotest/test_sfr.py
+++ b/autotest/test_sfr.py
@@ -17,6 +17,8 @@ Cases:
   - multi_period     : a stream measured after several periods.
   - sfr_with_lake    : a model holding both a stream and a lake borders them
                        together.
+  - branching        : a stream that splits sends its flow on in the shares the
+                       reaches below it are given.
 """
 
 import glob
@@ -475,6 +477,142 @@ def test_sfr_with_lake(tmp_path):
     adjoint, finite_difference = _compare_with_lake(
         tmp_path, with_lake=True, rgrd=1.0e-3, man=0.03
     )
+    assert np.isclose(adjoint, finite_difference, rtol=2e-2), (
+        f"adjoint {adjoint:.6e} against finite difference {finite_difference:.6e}"
+    )
+
+
+def test_sfr_branching(tmp_path):
+    """A stream that splits sends its flow on in the shares given below it.
+
+    Every other case is a single chain, where each reach passes its whole flow
+    to one reach below. Here reach 1 splits into two branches taking 0.7 and
+    0.3, and the measure follows one branch.
+
+    The shares are checked directly. The finite difference does not isolate
+    them: the share enters only the reach equations, and its contribution to
+    this measure is small beside the head response, so a wrong share still
+    reproduces the total.
+    """
+    dq = -50.0
+    # reach: cell, and the reaches it flows to
+    cells = [(3, 0), (3, 1), (2, 2), (4, 2), (2, 3), (4, 3)]
+    downstream = {0: [1], 1: [2, 3], 2: [4], 3: [5], 4: [], 5: []}
+    upstream = {0: [], 1: [0], 2: [1], 3: [1], 4: [2], 5: [3]}
+    shares = {2: 0.7, 3: 0.3}
+
+    def build(ws, rate):
+        ws = pl.Path(ws)
+        if ws.exists():
+            shutil.rmtree(ws)
+        sim = flopy.mf6.MFSimulation(
+            sim_name="sf", sim_ws=str(ws), exe_name=str(mf6_bin)
+        )
+        flopy.mf6.ModflowTdis(sim, nper=1, perioddata=[(100.0, 1, 1.0)])
+        flopy.mf6.ModflowIms(
+            sim,
+            outer_dvclose=1e-11,
+            inner_dvclose=1e-12,
+            outer_maximum=500,
+            complexity="complex",
+        )
+        gwf = flopy.mf6.ModflowGwf(sim, modelname="sf", save_flows=True)
+        flopy.mf6.ModflowGwfdis(
+            gwf,
+            nlay=1,
+            nrow=NROW,
+            ncol=NCOL,
+            delr=DELRC,
+            delc=DELRC,
+            top=10.0,
+            botm=[-20.0],
+        )
+        flopy.mf6.ModflowGwfic(gwf, strt=5.0)
+        flopy.mf6.ModflowGwfnpf(gwf, k=10.0, icelltype=0)
+        flopy.mf6.ModflowGwfsto(gwf, ss=1e-5, sy=0.2, transient={0: True})
+        spd = []
+        for i in range(NROW):
+            spd.append([(0, i, 0), 5.5, 1000.0])
+            spd.append([(0, i, NCOL - 1), 4.5, 1000.0])
+        flopy.mf6.ModflowGwfghb(gwf, stress_period_data=spd, pname="ghb-edge")
+        flopy.mf6.ModflowGwfwel(
+            gwf, stress_period_data=[[WELL_CELL, rate]], pname="wel-1"
+        )
+
+        packagedata, connectiondata = [], []
+        for n, (i, j) in enumerate(cells):
+            nconn = len(upstream[n]) + len(downstream[n])
+            packagedata.append(
+                [
+                    n,
+                    (0, i, j),
+                    DELRC,
+                    5.0,
+                    1.0e-5,
+                    STRTOP - 0.05 * n,
+                    1.0,
+                    5.0,
+                    0.3,
+                    nconn,
+                    shares.get(n, 1.0),
+                    0,
+                ]
+            )
+            conn = [n] + list(upstream[n]) + [-d for d in downstream[n]]
+            connectiondata.append(conn)
+        flopy.mf6.ModflowGwfsfr(
+            gwf,
+            nreaches=len(cells),
+            packagedata=packagedata,
+            connectiondata=connectiondata,
+            perioddata={0: [[0, "inflow", 5000.0]]},
+            unit_conversion=128390.0,
+            pname="sfr-1",
+        )
+        flopy.mf6.ModflowGwfoc(
+            gwf, head_filerecord="sf.hds", saverecord=[("HEAD", "ALL")]
+        )
+        sim.write_simulation(silent=True)
+        success, buff = sim.run_simulation(silent=True)
+        assert success, "\n".join(buff[-15:])
+
+        path = pl.Path(ws) / "test.adj"
+        with open(path, "w") as f:
+            f.write("begin performance_measure pm\n")
+            # one branch only: summing both would hide the split, since the
+            # total leaving the junction is the same however it is shared
+            for n in (2, 4):
+                i, j = cells[n]
+                f.write(f"1 1 1 {i + 1} {j + 1} sfr-1 direct 1.0 -1.0e+30\n")
+            f.write("end performance_measure\n")
+        _solve(ws)
+        return ws
+
+    ws_base = build(tmp_path / "base", WELL_RATE)
+    ws_pert = build(tmp_path / "pert", WELL_RATE + dq)
+
+    # the branches should carry the shares they were given
+    path = sorted(glob.glob(str(ws_base / "sf_*.hd5")))[-1]
+    with h5py.File(path, "r") as hf:
+        key = [k for k in hf if k.startswith("solution_")][-1]
+        fraction = hf[key]["sfr-1"]["reach_fraction"][:]
+        idir = hf[key]["sfr-1"]["reach_idir"][:]
+    split = sorted(round(float(f), 4) for f in fraction[idir > 0])
+    assert split == [0.3, 0.7, 1.0, 1.0, 1.0], (
+        f"the branches should take 0.3 and 0.7, got {split}"
+    )
+
+    def branch_leakage(ws):
+        """Return the exchange of the measured branch only."""
+        path = sorted(glob.glob(str(pl.Path(ws) / "sf_*.hd5")))[-1]
+        with h5py.File(path, "r") as hf:
+            key = [k for k in hf if k.startswith("solution_")][-1]
+            simvals = hf[key]["sfr-1"]["simvals"][:]
+        return float(simvals[2] + simvals[4])
+
+    finite_difference = (branch_leakage(ws_pert) - branch_leakage(ws_base)) / dq
+    with h5py.File(ws_base / "adjoint_solution_pm.hd5", "r") as hf:
+        adjoint = float(hf["composite"]["wel6_q"][WELL_CELL])
     assert np.isclose(adjoint, finite_difference, rtol=2e-2), (
         f"adjoint {adjoint:.6e} against finite difference {finite_difference:.6e}"
     )

--- a/autotest/test_sfr.py
+++ b/autotest/test_sfr.py
@@ -14,6 +14,9 @@ Cases:
                        pumping cannot change, and the adjoint returns zero.
   - two_packages     : two streamflow-routing packages in one model each keep
                        their own reaches.
+  - multi_period     : a stream measured after several periods.
+  - sfr_with_lake    : a model holding both a stream and a lake borders them
+                       together.
 """
 
 import glob
@@ -324,6 +327,154 @@ def test_two_sfr_packages(tmp_path):
     finite_difference = (pert - base) / dq
     with h5py.File(ws_base / "adjoint_solution_pm.hd5", "r") as hf:
         adjoint = float(hf["composite"]["wel6_q"][WELL_CELL])
+    assert np.isclose(adjoint, finite_difference, rtol=2e-2), (
+        f"adjoint {adjoint:.6e} against finite difference {finite_difference:.6e}"
+    )
+
+
+def _build_with_lake(ws, well_rate, nper=1, with_lake=False, rgrd=1.0e-5, man=0.3):
+    """Build the stream model, optionally over several periods or with a lake."""
+    ws = pl.Path(ws)
+    if ws.exists():
+        shutil.rmtree(ws)
+    lake_cells = [(6, 2), (6, 3)]
+    nlay = 2 if with_lake else 1
+    botm = [0.0, -20.0] if with_lake else [-20.0]
+    sim = flopy.mf6.MFSimulation(sim_name="sf", sim_ws=str(ws), exe_name=str(mf6_bin))
+    flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=[(50.0, 1, 1.0)] * nper)
+    flopy.mf6.ModflowIms(
+        sim,
+        outer_dvclose=1e-11,
+        inner_dvclose=1e-12,
+        outer_maximum=500,
+        complexity="complex",
+    )
+    gwf = flopy.mf6.ModflowGwf(sim, modelname="sf", save_flows=True)
+    idomain = np.ones((nlay, NROW, NCOL), dtype=int)
+    if with_lake:
+        for i, j in lake_cells:
+            idomain[0, i, j] = 0
+    flopy.mf6.ModflowGwfdis(
+        gwf,
+        nlay=nlay,
+        nrow=NROW,
+        ncol=NCOL,
+        delr=DELRC,
+        delc=DELRC,
+        top=10.0,
+        botm=botm,
+        idomain=idomain,
+    )
+    flopy.mf6.ModflowGwfic(gwf, strt=5.0)
+    flopy.mf6.ModflowGwfnpf(gwf, k=10.0, icelltype=0)
+    flopy.mf6.ModflowGwfsto(
+        gwf, ss=1e-5, sy=0.2, transient=dict.fromkeys(range(nper), True)
+    )
+    spd = []
+    for k in range(nlay):
+        for i in range(NROW):
+            spd.append([(k, i, 0), 5.5, 1000.0])
+            spd.append([(k, i, NCOL - 1), 4.5, 1000.0])
+    flopy.mf6.ModflowGwfghb(gwf, stress_period_data=spd, pname="ghb-edge")
+    well = (nlay - 1, 6, 6)
+    flopy.mf6.ModflowGwfwel(
+        gwf, stress_period_data={0: [[well, well_rate]]}, pname="wel-1"
+    )
+    packagedata, connectiondata = [], []
+    for n in range(NCOL):
+        nconn = 1 if n in (0, NCOL - 1) else 2
+        packagedata.append(
+            [
+                n,
+                (0, REACH_ROW, n),
+                DELRC,
+                5.0,
+                rgrd,
+                STRTOP - 0.01 * n,
+                1.0,
+                5.0,
+                man,
+                nconn,
+                1.0,
+                0,
+            ]
+        )
+        conn = [n]
+        if n > 0:
+            conn.append(n - 1)
+        if n < NCOL - 1:
+            conn.append(-(n + 1))
+        connectiondata.append(conn)
+    flopy.mf6.ModflowGwfsfr(
+        gwf,
+        nreaches=NCOL,
+        packagedata=packagedata,
+        connectiondata=connectiondata,
+        perioddata={0: [[0, "inflow", 5000.0]]},
+        unit_conversion=128390.0,
+        pname="sfr-1",
+    )
+    if with_lake:
+        lconn = [
+            [0, m, (1, i, j), "vertical", 0.1, 0.0, 0.0, 0.0, 0.0]
+            for m, (i, j) in enumerate(lake_cells)
+        ]
+        flopy.mf6.ModflowGwflak(
+            gwf,
+            nlakes=1,
+            noutlets=0,
+            ntables=0,
+            packagedata=[[0, 6.0, len(lconn)]],
+            connectiondata=lconn,
+            pname="lak-1",
+        )
+    flopy.mf6.ModflowGwfoc(gwf, head_filerecord="sf.hds", saverecord=[("HEAD", "ALL")])
+    sim.write_simulation(silent=True)
+    success, buff = sim.run_simulation(silent=True)
+    assert success, "\n".join(buff[-15:])
+
+    path = pl.Path(ws) / "test.adj"
+    with open(path, "w") as f:
+        f.write("begin performance_measure pm\n")
+        for n in range(NCOL):
+            f.write(f"{nper} 1 1 {REACH_ROW + 1} {n + 1} sfr-1 direct 1.0 -1.0e+30\n")
+        f.write("end performance_measure\n")
+    _solve(ws)
+    return ws, well
+
+
+def _compare_with_lake(tmpdir, **kwargs):
+    dq = -50.0
+    base, well = _build_with_lake(tmpdir / "base", WELL_RATE, **kwargs)
+    pert, _ = _build_with_lake(tmpdir / "pert", WELL_RATE + dq, **kwargs)
+    finite_difference = (_measure_value(pert) - _measure_value(base)) / dq
+    with h5py.File(base / "adjoint_solution_pm.hd5", "r") as hf:
+        adjoint = float(hf["composite"]["wel6_q"][well])
+    return adjoint, finite_difference
+
+
+def test_sfr_multi_period(tmp_path):
+    """A stream measured after several periods.
+
+    A reach carries no storage, so nothing passes between steps, but the reach
+    equations still have to be built and taken apart at every step of the
+    backward sweep.
+    """
+    adjoint, finite_difference = _compare_with_lake(tmp_path, nper=5)
+    assert np.isclose(adjoint, finite_difference, rtol=2e-2), (
+        f"adjoint {adjoint:.6e} against finite difference {finite_difference:.6e}"
+    )
+
+
+def test_sfr_with_lake(tmp_path):
+    """A model holding both a stream and a lake borders them together.
+
+    The reach rows sit outside the lake rows, so the two have to share one
+    system without treading on each other.
+    """
+    adjoint, finite_difference = _compare_with_lake(
+        tmp_path, with_lake=True, rgrd=1.0e-3, man=0.03
+    )
     assert np.isclose(adjoint, finite_difference, rtol=2e-2), (
         f"adjoint {adjoint:.6e} against finite difference {finite_difference:.6e}"
     )

--- a/autotest/test_sfr.py
+++ b/autotest/test_sfr.py
@@ -8,10 +8,11 @@ derivative. These cases measure how far that is from the total derivative.
 Cases:
   - sfr_shallow      : a steep, shallow stream barely moves its stage, so the
                        frozen-stage result is already close.
-  - sfr_deep         : a slow, deep stream moves its stage enough that the
-                       frozen-stage result is well out (xfail).
+  - sfr_deep         : a slow, deep stream moves its stage, and the reach
+                       equation carries that.
   - sfr_fully_losing : a stream that loses all of its inflow has a leakage the
-                       pumping cannot change, and the adjoint should say so
+                       pumping cannot change, which needs the reach that gives
+                       up its whole flow to be coupled to the reaches above it
                        (xfail).
 """
 
@@ -172,17 +173,13 @@ def test_sfr_shallow(tmp_path):
     )
 
 
-@pytest.mark.xfail(
-    reason="the adjoint holds the reach stage fixed, so a stream deep enough to "
-    "move its stage returns a partial derivative (INTERA-Inc/mf6adj#78)",
-    strict=False,
-)
 def test_sfr_deep(tmp_path):
-    """A slow, deep stream moves its stage enough for the frozen result to be out.
+    """A slow, deep stream moves its stage, and the reach equation carries that.
 
     Depth follows flow, so a stream with a gentle slope and a rough bed carries
     its water deep and slowly. Pumping takes water from the stream, the flow
-    drops, the stage falls with it, and that second effect is missing.
+    drops, and the stage falls with it. Holding the stage fixed misses that
+    second effect and is a quarter out.
     """
     adjoint, finite_difference = _compare(tmp_path, rgrd=1.0e-5, man=0.3, rhk=5.0)
     assert np.isclose(adjoint, finite_difference, rtol=2e-2), (
@@ -191,16 +188,19 @@ def test_sfr_deep(tmp_path):
 
 
 @pytest.mark.xfail(
-    reason="a fully losing stream has a leakage the pumping cannot change, but "
-    "the frozen reach stage hides that (INTERA-Inc/mf6adj#78)",
+    reason="the reach that gives up its whole flow leaks its own inflow rather "
+    "than a head-dependent amount, and that coupling to the reaches above it is "
+    "not formed (INTERA-Inc/mf6adj#78)",
     strict=False,
 )
 def test_sfr_fully_losing(tmp_path):
     """A stream that loses all its inflow has a leakage pumping cannot change.
 
     Every drop that enters the stream reaches the aquifer, so the total
-    exchange is the inflow whatever the pumping does. The adjoint has to return
-    zero, and it will once the reach equation is solved with the flow equations.
+    exchange is the inflow whatever the pumping does, and the adjoint has to
+    return zero. The last reach gives up all of the water it carries, so its
+    leakage follows the reaches above it rather than its own stage; until that
+    coupling is formed the reach equations cannot pin the total.
     """
     adjoint, finite_difference = _compare(tmp_path, rgrd=1.0e-5, man=0.3, rhk=50.0)
     assert abs(finite_difference) < 1e-6, (

--- a/autotest/test_sfr.py
+++ b/autotest/test_sfr.py
@@ -12,6 +12,8 @@ Cases:
                        equation carries that.
   - sfr_fully_losing : a stream that loses all of its inflow has a leakage the
                        pumping cannot change, and the adjoint returns zero.
+  - two_packages     : two streamflow-routing packages in one model each keep
+                       their own reaches.
 """
 
 import glob
@@ -201,4 +203,127 @@ def test_sfr_fully_losing(tmp_path):
     )
     assert abs(adjoint) < 1e-6, (
         f"the adjoint reports {adjoint:.6e} where there is no sensitivity"
+    )
+
+
+def test_two_sfr_packages(tmp_path):
+    """Two streamflow-routing packages in one model each keep their own reaches.
+
+    Every package writes its own forward terms and its own columns, so a
+    measure on one must not pick up the other.
+    """
+    dq = -50.0
+    first_row, second_row = 2, 5
+
+    def build(ws, rate):
+        ws = pl.Path(ws)
+        if ws.exists():
+            shutil.rmtree(ws)
+        sim = flopy.mf6.MFSimulation(
+            sim_name="sf", sim_ws=str(ws), exe_name=str(mf6_bin)
+        )
+        flopy.mf6.ModflowTdis(sim, nper=1, perioddata=[(100.0, 1, 1.0)])
+        flopy.mf6.ModflowIms(
+            sim,
+            outer_dvclose=1e-11,
+            inner_dvclose=1e-12,
+            outer_maximum=500,
+            complexity="complex",
+        )
+        gwf = flopy.mf6.ModflowGwf(sim, modelname="sf", save_flows=True)
+        flopy.mf6.ModflowGwfdis(
+            gwf,
+            nlay=1,
+            nrow=NROW,
+            ncol=NCOL,
+            delr=DELRC,
+            delc=DELRC,
+            top=10.0,
+            botm=[-20.0],
+        )
+        flopy.mf6.ModflowGwfic(gwf, strt=5.0)
+        flopy.mf6.ModflowGwfnpf(gwf, k=10.0, icelltype=0)
+        flopy.mf6.ModflowGwfsto(gwf, ss=1e-5, sy=0.2, transient={0: True})
+        spd = []
+        for i in range(NROW):
+            spd.append([(0, i, 0), 5.5, 1000.0])
+            spd.append([(0, i, NCOL - 1), 4.5, 1000.0])
+        flopy.mf6.ModflowGwfghb(gwf, stress_period_data=spd, pname="ghb-edge")
+        flopy.mf6.ModflowGwfwel(
+            gwf, stress_period_data=[[WELL_CELL, rate]], pname="wel-1"
+        )
+        for name, row in (("sfr-a", first_row), ("sfr-b", second_row)):
+            packagedata, connectiondata = [], []
+            for n in range(NCOL):
+                nconn = 1 if n in (0, NCOL - 1) else 2
+                packagedata.append(
+                    [
+                        n,
+                        (0, row, n),
+                        DELRC,
+                        5.0,
+                        1.0e-3,
+                        STRTOP - 0.01 * n,
+                        1.0,
+                        5.0,
+                        0.03,
+                        nconn,
+                        1.0,
+                        0,
+                    ]
+                )
+                conn = [n]
+                if n > 0:
+                    conn.append(n - 1)
+                if n < NCOL - 1:
+                    conn.append(-(n + 1))
+                connectiondata.append(conn)
+            flopy.mf6.ModflowGwfsfr(
+                gwf,
+                nreaches=NCOL,
+                packagedata=packagedata,
+                connectiondata=connectiondata,
+                perioddata={0: [[0, "inflow", 5000.0]]},
+                unit_conversion=128390.0,
+                pname=name,
+                filename=f"sf.{name}.sfr",
+            )
+        flopy.mf6.ModflowGwfoc(
+            gwf, head_filerecord="sf.hds", saverecord=[("HEAD", "ALL")]
+        )
+        sim.write_simulation(silent=True)
+        success, buff = sim.run_simulation(silent=True)
+        assert success, "\n".join(buff[-15:])
+
+        # measure the exchange of the first package only
+        path = pl.Path(ws) / "test.adj"
+        with open(path, "w") as f:
+            f.write("begin performance_measure pm\n")
+            for n in range(NCOL):
+                f.write(f"1 1 1 {first_row + 1} {n + 1} sfr-a direct 1.0 -1.0e+30\n")
+            f.write("end performance_measure\n")
+        _solve(ws)
+        return ws
+
+    ws_base = build(tmp_path / "base", WELL_RATE)
+    ws_pert = build(tmp_path / "pert", WELL_RATE + dq)
+
+    def measured(ws):
+        path = sorted(glob.glob(str(pl.Path(ws) / "sf_*.hd5")))[-1]
+        with h5py.File(path, "r") as hf:
+            key = [k for k in hf if k.startswith("solution_")][-1]
+            names = sorted(k for k in hf[key] if k.startswith("sfr-"))
+            return float(np.sum(hf[key]["sfr-a"]["simvals"][:])), names
+
+    base, names = measured(ws_base)
+    pert, _ = measured(ws_pert)
+    assert names == ["sfr-a", "sfr-b"], (
+        f"each package should write its own group, got {names}"
+    )
+
+    finite_difference = (pert - base) / dq
+    with h5py.File(ws_base / "adjoint_solution_pm.hd5", "r") as hf:
+        adjoint = float(hf["composite"]["wel6_q"][WELL_CELL])
+    assert np.isclose(adjoint, finite_difference, rtol=2e-2), (
+        f"adjoint {adjoint:.6e} against finite difference {finite_difference:.6e}"
     )

--- a/autotest/test_sfr.py
+++ b/autotest/test_sfr.py
@@ -1,0 +1,212 @@
+"""
+Tests for streamflow routing (SFR) performance measures.
+
+A reach stage follows the flow through the reach, so it is a dependent variable
+in the same sense as a lake stage. Holding it fixed returns a partial
+derivative. These cases measure how far that is from the total derivative.
+
+Cases:
+  - sfr_shallow      : a steep, shallow stream barely moves its stage, so the
+                       frozen-stage result is already close.
+  - sfr_deep         : a slow, deep stream moves its stage enough that the
+                       frozen-stage result is well out (xfail).
+  - sfr_fully_losing : a stream that loses all of its inflow has a leakage the
+                       pumping cannot change, and the adjoint should say so
+                       (xfail).
+"""
+
+import glob
+import pathlib as pl
+import shutil
+import sys
+
+import flopy
+import h5py
+import numpy as np
+import pytest
+
+try:
+    import mf6adj
+except ImportError:
+    sys.path.insert(0, str(pl.Path("../").resolve()))
+    import mf6adj
+
+mf6_bin, lib_name = mf6adj.get_conda_mf6_paths()
+
+NROW, NCOL, DELRC = 8, 8, 100.0
+REACH_ROW = 3
+WELL_CELL = (0, 6, 6)
+WELL_RATE = -2000.0
+STRTOP = 6.0
+
+
+def _build_model(ws, well_rate, inflow=5000.0, rhk=5.0, rgrd=1.0e-3, man=0.03):
+    """Build a single-layer model with a chain of reaches across it."""
+    ws = pl.Path(ws)
+    if ws.exists():
+        shutil.rmtree(ws)
+    sim = flopy.mf6.MFSimulation(sim_name="sf", sim_ws=str(ws), exe_name=str(mf6_bin))
+    flopy.mf6.ModflowTdis(sim, nper=1, perioddata=[(100.0, 1, 1.0)])
+    flopy.mf6.ModflowIms(
+        sim,
+        outer_dvclose=1e-11,
+        inner_dvclose=1e-12,
+        outer_maximum=500,
+        complexity="complex",
+    )
+    gwf = flopy.mf6.ModflowGwf(sim, modelname="sf", save_flows=True)
+    flopy.mf6.ModflowGwfdis(
+        gwf,
+        nlay=1,
+        nrow=NROW,
+        ncol=NCOL,
+        delr=DELRC,
+        delc=DELRC,
+        top=10.0,
+        botm=[-20.0],
+    )
+    flopy.mf6.ModflowGwfic(gwf, strt=5.0)
+    flopy.mf6.ModflowGwfnpf(gwf, k=10.0, icelltype=0)
+    flopy.mf6.ModflowGwfsto(gwf, ss=1e-5, sy=0.2, transient={0: True})
+    spd = []
+    for i in range(NROW):
+        spd.append([(0, i, 0), 5.5, 1000.0])
+        spd.append([(0, i, NCOL - 1), 4.5, 1000.0])
+    flopy.mf6.ModflowGwfghb(gwf, stress_period_data=spd, pname="ghb-edge")
+    flopy.mf6.ModflowGwfwel(
+        gwf, stress_period_data=[[WELL_CELL, well_rate]], pname="wel-1"
+    )
+
+    packagedata, connectiondata = [], []
+    for n in range(NCOL):
+        nconn = 1 if n in (0, NCOL - 1) else 2
+        packagedata.append(
+            [
+                n,
+                (0, REACH_ROW, n),
+                DELRC,
+                5.0,
+                rgrd,
+                STRTOP - 0.01 * n,
+                1.0,
+                rhk,
+                man,
+                nconn,
+                1.0,
+                0,
+            ]
+        )
+        conn = [n]
+        if n > 0:
+            conn.append(n - 1)
+        if n < NCOL - 1:
+            # a downstream connection is given as a negative reach number
+            conn.append(-(n + 1))
+        connectiondata.append(conn)
+    flopy.mf6.ModflowGwfsfr(
+        gwf,
+        nreaches=NCOL,
+        packagedata=packagedata,
+        connectiondata=connectiondata,
+        perioddata={0: [[0, "inflow", inflow]]},
+        unit_conversion=128390.0,
+        pname="sfr-1",
+    )
+    flopy.mf6.ModflowGwfoc(gwf, head_filerecord="sf.hds", saverecord=[("HEAD", "ALL")])
+    sim.write_simulation(silent=True)
+    success, buff = sim.run_simulation(silent=True)
+    assert success, "\n".join(buff[-15:])
+    return ws
+
+
+def _write_adj(ws):
+    """Measure the exchange between every reach and the aquifer."""
+    path = pl.Path(ws) / "test.adj"
+    with open(path, "w") as f:
+        f.write("begin performance_measure pm\n")
+        for n in range(NCOL):
+            f.write(f"1 1 1 {REACH_ROW + 1} {n + 1} sfr-1 direct 1.0 -1.0e+30\n")
+        f.write("end performance_measure\n")
+    return path
+
+
+def _solve(ws):
+    adj = mf6adj.Mf6Adj(
+        "test.adj", str(lib_name), logging_level="WARNING", working_directory=str(ws)
+    )
+    adj.solve_forward_model()
+    dfs = adj.solve_adjoint()
+    adj.finalize()
+    return dfs
+
+
+def _measure_value(ws):
+    """Return the reach exchange mf6adj summed."""
+    path = sorted(glob.glob(str(pl.Path(ws) / "sf_*.hd5")))[-1]
+    with h5py.File(path, "r") as hf:
+        key = [k for k in hf if k.startswith("solution_")][-1]
+        return float(np.sum(hf[key]["sfr-1"]["simvals"][:]))
+
+
+def _compare(tmpdir, **kwargs):
+    """Return the adjoint sensitivity and its finite-difference counterpart."""
+    dq = -50.0
+    base = _build_model(tmpdir / "base", WELL_RATE, **kwargs)
+    _write_adj(base)
+    _solve(base)
+    pert = _build_model(tmpdir / "pert", WELL_RATE + dq, **kwargs)
+    _write_adj(pert)
+    _solve(pert)
+
+    finite_difference = (_measure_value(pert) - _measure_value(base)) / dq
+    with h5py.File(base / "adjoint_solution_pm.hd5", "r") as hf:
+        adjoint = float(hf["composite"]["wel6_q"][WELL_CELL])
+    return adjoint, finite_difference
+
+
+def test_sfr_shallow(tmp_path):
+    """A steep, shallow stream hardly moves its stage, so freezing it is close."""
+    adjoint, finite_difference = _compare(tmp_path, rgrd=1.0e-3, man=0.03, rhk=5.0)
+    assert np.isclose(adjoint, finite_difference, rtol=2e-2), (
+        f"adjoint {adjoint:.6e} against finite difference {finite_difference:.6e}"
+    )
+
+
+@pytest.mark.xfail(
+    reason="the adjoint holds the reach stage fixed, so a stream deep enough to "
+    "move its stage returns a partial derivative (INTERA-Inc/mf6adj#78)",
+    strict=False,
+)
+def test_sfr_deep(tmp_path):
+    """A slow, deep stream moves its stage enough for the frozen result to be out.
+
+    Depth follows flow, so a stream with a gentle slope and a rough bed carries
+    its water deep and slowly. Pumping takes water from the stream, the flow
+    drops, the stage falls with it, and that second effect is missing.
+    """
+    adjoint, finite_difference = _compare(tmp_path, rgrd=1.0e-5, man=0.3, rhk=5.0)
+    assert np.isclose(adjoint, finite_difference, rtol=2e-2), (
+        f"adjoint {adjoint:.6e} against finite difference {finite_difference:.6e}"
+    )
+
+
+@pytest.mark.xfail(
+    reason="a fully losing stream has a leakage the pumping cannot change, but "
+    "the frozen reach stage hides that (INTERA-Inc/mf6adj#78)",
+    strict=False,
+)
+def test_sfr_fully_losing(tmp_path):
+    """A stream that loses all its inflow has a leakage pumping cannot change.
+
+    Every drop that enters the stream reaches the aquifer, so the total
+    exchange is the inflow whatever the pumping does. The adjoint has to return
+    zero, and it will once the reach equation is solved with the flow equations.
+    """
+    adjoint, finite_difference = _compare(tmp_path, rgrd=1.0e-5, man=0.3, rhk=50.0)
+    assert abs(finite_difference) < 1e-6, (
+        "the stream should lose all of its inflow, so the exchange cannot "
+        f"respond to pumping, but the finite difference is {finite_difference:.6e}"
+    )
+    assert abs(adjoint) < 1e-6, (
+        f"the adjoint reports {adjoint:.6e} where there is no sensitivity"
+    )

--- a/autotest/test_sfr.py
+++ b/autotest/test_sfr.py
@@ -11,9 +11,7 @@ Cases:
   - sfr_deep         : a slow, deep stream moves its stage, and the reach
                        equation carries that.
   - sfr_fully_losing : a stream that loses all of its inflow has a leakage the
-                       pumping cannot change, which needs the reach that gives
-                       up its whole flow to be coupled to the reaches above it
-                       (xfail).
+                       pumping cannot change, and the adjoint returns zero.
 """
 
 import glob
@@ -187,20 +185,14 @@ def test_sfr_deep(tmp_path):
     )
 
 
-@pytest.mark.xfail(
-    reason="the reach that gives up its whole flow leaks its own inflow rather "
-    "than a head-dependent amount, and that coupling to the reaches above it is "
-    "not formed (INTERA-Inc/mf6adj#78)",
-    strict=False,
-)
 def test_sfr_fully_losing(tmp_path):
     """A stream that loses all its inflow has a leakage pumping cannot change.
 
     Every drop that enters the stream reaches the aquifer, so the total
     exchange is the inflow whatever the pumping does, and the adjoint has to
     return zero. The last reach gives up all of the water it carries, so its
-    leakage follows the reaches above it rather than its own stage; until that
-    coupling is formed the reach equations cannot pin the total.
+    leakage follows the reaches above it rather than its own stage, and it is
+    that coupling which pins the total.
     """
     adjoint, finite_difference = _compare(tmp_path, rgrd=1.0e-5, man=0.3, rhk=50.0)
     assert abs(finite_difference) < 1e-6, (

--- a/changelog/CHANGELOG.md
+++ b/changelog/CHANGELOG.md
@@ -42,6 +42,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `BOUND`, which MODFLOW 6 leaves allocated but zeroed. The stage and
   conductance sensitivities of `ghb6`, `riv6`, `drn6`, and `chd6` were reported
   as zero.
+- Each streamflow-routing package writes its own forward terms. The reach stage
+  lookup took the first package in the model rather than the one being written,
+  so a model with more than one wrote them all under the first package's name.
 - A cell holding more than one boundary from the same package accumulates all
   of them rather than keeping only the last.
 - A flux performance measure uses its entry weight, and its direct term is

--- a/changelog/CHANGELOG.md
+++ b/changelog/CHANGELOG.md
@@ -5,50 +5,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-
-### Breaking changes
-
-- A model whose packages add their own equations to the MODFLOW 6 solution
-  matrix is rejected instead of returning corrupted sensitivities. `maw6`
-  always adds equations, and so does an implicitly coupled lake (MODFLOW 6
-  6.8.0 and later); `sfr6`, `lak6`, and `uzf6` are solved in the outer
-  iteration and are unaffected.
-
-### Added
-
-- The reach routing equations are solved with the flow equations, so a
-  sensitivity to a stream is a total derivative rather than one that holds the
-  reach stage fixed. It matters where a stream is deep and slow enough for its
-  stage to follow its flow, where the frozen stage was a quarter out, and where
-  a stream loses all of its inflow and has no sensitivity at all. Reaches with a
-  cross section and reaches taking a diversion are not differentiated, and are
-  reported as warnings.
-
-- `lak6` performance measures, so a measure can sum the exchange between a lake
-  and the aquifer, with lake stage and conductance among the parameters.
-- The lake water balance is solved with the flow equations, so a sensitivity to
-  a lake with a free stage is a total derivative rather than one that holds the
-  stage fixed. Outlets, stage-volume-area tables, rainfall, and evaporation are
-  included, and a lake perched above the water table is coupled only through
-  its stage, since the head beneath it no longer sets the leakage. Inflows routed to a lake by `mvr6`, and the stage dependence of a
-  horizontal connection's conductance, are not, and are reported as warnings.
-
-### Fixed
-
-- Boundary values are read from each package's own arrays rather than from
-  `BOUND`, which MODFLOW 6 leaves allocated but zeroed. The stage and
-  conductance sensitivities of `ghb6`, `riv6`, `drn6`, and `chd6` were reported
-  as zero.
-- Each streamflow-routing package writes its own forward terms. The reach stage
-  lookup took the first package in the model rather than the one being written,
-  so a model with more than one wrote them all under the first package's name.
-- A cell holding more than one boundary from the same package accumulates all
-  of them rather than keeping only the last.
-- A flux performance measure uses its entry weight, and its direct term is
-  applied only to the boundaries the measure names rather than to every
-  head-dependent package.
-
 ## [1.2.0] - 2026-08-03
 
 ### Breaking changes

--- a/changelog/CHANGELOG.md
+++ b/changelog/CHANGELOG.md
@@ -17,6 +17,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- The reach routing equations are solved with the flow equations, so a
+  sensitivity to a stream is a total derivative rather than one that holds the
+  reach stage fixed. It matters where a stream is deep and slow enough for its
+  stage to follow its flow: on a test stream the frozen stage was a quarter
+  out. Reaches with a cross section, reaches taking a diversion, and a reach
+  that gives up all of the water it carries are not differentiated and are
+  reported as warnings.
+
 - `lak6` performance measures, so a measure can sum the exchange between a lake
   and the aquifer, with lake stage and conductance among the parameters.
 - The lake water balance is solved with the flow equations, so a sensitivity to

--- a/changelog/CHANGELOG.md
+++ b/changelog/CHANGELOG.md
@@ -20,12 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The reach routing equations are solved with the flow equations, so a
   sensitivity to a stream is a total derivative rather than one that holds the
   reach stage fixed. It matters where a stream is deep and slow enough for its
-  stage to follow its flow: on a test stream the frozen stage was a quarter
-  out. A reach that gives up all of the water it carries leaks its own inflow,
-  so it is coupled to the reaches above it rather than to its own stage, which
-  is what lets a fully losing stream report the zero sensitivity it has.
-  Reaches with a cross section and reaches taking a diversion are not
-  differentiated and are reported as warnings.
+  stage to follow its flow, where the frozen stage was a quarter out, and where
+  a stream loses all of its inflow and has no sensitivity at all. Reaches with a
+  cross section and reaches taking a diversion are not differentiated, and are
+  reported as warnings.
 
 - `lak6` performance measures, so a measure can sum the exchange between a lake
   and the aquifer, with lake stage and conductance among the parameters.

--- a/changelog/CHANGELOG.md
+++ b/changelog/CHANGELOG.md
@@ -21,9 +21,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   sensitivity to a stream is a total derivative rather than one that holds the
   reach stage fixed. It matters where a stream is deep and slow enough for its
   stage to follow its flow: on a test stream the frozen stage was a quarter
-  out. Reaches with a cross section, reaches taking a diversion, and a reach
-  that gives up all of the water it carries are not differentiated and are
-  reported as warnings.
+  out. A reach that gives up all of the water it carries leaks its own inflow,
+  so it is coupled to the reaches above it rather than to its own stage, which
+  is what lets a fully losing stream report the zero sensitivity it has.
+  Reaches with a cross section and reaches taking a diversion are not
+  differentiated and are reported as warnings.
 
 - `lak6` performance measures, so a measure can sum the exchange between a lake
   and the aquifer, with lake stage and conductance among the parameters.

--- a/mf6adj/adj.py
+++ b/mf6adj/adj.py
@@ -852,7 +852,9 @@ class Mf6Adj:
                                         bound[:, i] = vals
 
                                 if package_type == "sfr6":
-                                    tag = self._gwf_package_dict[package_type][0]
+                                    # tag is already this package: taking the
+                                    # first one instead wrote every streamflow
+                                    # routing package under that name
                                     stage = self._gwf.get_value(
                                         self._gwf.get_var_address(
                                             "STAGE", self._gwf_name, tag.upper()

--- a/mf6adj/adj.py
+++ b/mf6adj/adj.py
@@ -13,7 +13,7 @@ import numpy as np
 import pandas as pd
 from xmipy.errors import XMIError
 
-from .advanced_packages.lake import forward_terms as lake_forward_terms
+from .advanced_packages import lake_forward_terms, sfr_forward_terms
 from .pm import PerfMeas, PerfMeasRecord
 from .utils.utils import _utils_cd
 from .utils.utils_fileio import _write_group_to_hdf
@@ -891,6 +891,12 @@ class Mf6Adj:
                                         + f"data dict for {tag}"
                                     )
                                     data_dict[tag][key] = val
+                                if package_type == "sfr6":
+                                    data_dict[tag].update(
+                                        sfr_forward_terms(
+                                            self._gwf, self._gwf_name, tag
+                                        )
+                                    )
                                 if package_type == "lak6":
                                     # the hdf writer nests one level, so these
                                     # sit alongside the package arrays

--- a/mf6adj/advanced_packages/__init__.py
+++ b/mf6adj/advanced_packages/__init__.py
@@ -7,10 +7,15 @@ is bordered with the package's own equation. Each package keeps its terms in a
 module here, leaving the adjoint solver free of package detail.
 """
 
-from .lake import LakeCoupling, forward_terms, table_slope
+from .lake import LakeCoupling, table_slope
+from .lake import forward_terms as lake_forward_terms
+from .sfr import SfrCoupling
+from .sfr import forward_terms as sfr_forward_terms
 
 __all__ = [
     "LakeCoupling",
-    "forward_terms",
+    "SfrCoupling",
+    "lake_forward_terms",
+    "sfr_forward_terms",
     "table_slope",
 ]

--- a/mf6adj/advanced_packages/sfr.py
+++ b/mf6adj/advanced_packages/sfr.py
@@ -1,0 +1,343 @@
+"""Streamflow routing (SFR) coupling for the adjoint solution.
+
+A reach stage follows the flow through the reach, so it is a dependent variable
+just as a lake stage is, and holding it fixed returns a partial derivative. The
+adjoint system is bordered with one equation per reach, and those equations
+carry the routing between reaches.
+
+MODFLOW 6 sets a reach depth so that the Manning discharge equals the mean of
+the flow entering and leaving the reach::
+
+    qman(d) = (Q_in + Q_out) / 2,     Q_out = Q_in - leak
+
+For a reach without a cross section the wetted perimeter is the reach width
+with no depth dependence, so the discharge is a power of the depth::
+
+    qman(d) = unitconv * width * d ** (5 / 3) * sqrt(slope) / roughness
+
+and its derivative is that exponent times the discharge over the depth. Taking
+the discharge MODFLOW reports rather than rebuilding the rating keeps this
+correct whatever the unit conversion is.
+"""
+
+import numpy as np
+import scipy.sparse as sparse
+
+# The Manning discharge of a reach without a cross section is this power of the
+# depth over the streambed, so its derivative is the exponent times the
+# discharge over the depth.
+MANNING_EXPONENT = 5.0 / 3.0
+
+# MODFLOW 6 smooths the discharge to zero below this depth, and that smoothing
+# is not reproduced here, so a shallower reach is treated as carrying no flow.
+MIN_DEPTH = 1.0e-5
+
+
+def _rating_discharge(width, depth, slope, rough, unitconv):
+    """Return the Manning discharge of a reach without a cross section."""
+    return unitconv * width * depth**MANNING_EXPONENT * np.sqrt(slope) / rough
+
+
+def forward_terms(gwf, gwf_name: str, tag: str) -> dict:
+    """Return the routing terms of a streamflow-routing package for one time step.
+
+    Parameters
+    ----------
+    gwf : modflowapi.ModflowApi
+        MODFLOW 6 groundwater-flow instance.
+    gwf_name : str
+        Name of the groundwater-flow model.
+    tag : str
+        Streamflow-routing package name from the GWF name file.
+
+    Returns
+    -------
+    dict
+        Depth, discharge, the derivative of discharge with respect to depth,
+        and the reach network. ``reach_is_free`` marks a reach whose depth is
+        solved, as opposed to one that is dry or holds a specified stage.
+    """
+
+    def value(name):
+        return gwf.get_value(gwf.get_var_address(name, gwf_name, tag.upper())).copy()
+
+    def optional(name, default, size):
+        """Return a package quantity, or a default where MODFLOW omits it."""
+        try:
+            return value(name)
+        except Exception:
+            return np.full(size, default)
+
+    depth = value("DEPTH")
+    nreach = depth.shape[0]
+    hcof = value("HCOF")
+    dsflow = value("DSFLOW")
+    width = value("WIDTH")
+    slope = value("SLOPE")
+    rough = value("ROUGH")
+    unitconv = float(value("UNITCONV")[0])
+
+    # a reach with a cross section follows a rating this does not reproduce
+    ncrosspts = optional("NCROSSPTS", 1, nreach)
+    has_section = (ncrosspts > 1).astype(int)
+
+    discharge = np.zeros(nreach)
+    ddischarge = np.zeros(nreach)
+    for n in range(nreach):
+        if depth[n] <= MIN_DEPTH or has_section[n]:
+            continue
+        discharge[n] = _rating_discharge(
+            width[n], depth[n], slope[n], rough[n], unitconv
+        )
+        ddischarge[n] = MANNING_EXPONENT * discharge[n] / depth[n]
+
+    # A reach that gives up every drop it carries leaks its own inflow rather
+    # than a head-dependent amount, which MODFLOW marks by leaving hcof at zero
+    # while the reach still holds water. That leakage follows the reaches above
+    # it rather than its own stage, and that coupling is not formed here.
+    flow_limited = ((hcof == 0.0) & (depth > MIN_DEPTH) & (dsflow <= 0.0)).astype(int)
+
+    # a reach that carries no water, whose stage follows a cross section, or
+    # whose leakage is limited by the flow it carries, has no depth for the
+    # adjoint to solve for
+    is_free = ((depth > MIN_DEPTH) & (has_section == 0) & (flow_limited == 0)).astype(
+        int
+    )
+
+    # the reach network: idir is positive for a connection to an upstream reach
+    ia = value("IA") - 1
+    ja = value("JA") - 1
+    idir = value("IDIR")
+    ustrf = value("USTRF")
+
+    # the share of an upstream reach's outflow this reach receives
+    total = np.zeros(nreach)
+    for n in range(nreach):
+        for icon in range(ia[n], ia[n + 1]):
+            if idir[icon] > 0:
+                # ja[icon] is upstream of n, so n is one of its outflows
+                total[ja[icon]] += ustrf[n]
+    fraction = np.zeros(ja.shape[0])
+    for n in range(nreach):
+        for icon in range(ia[n], ia[n + 1]):
+            if idir[icon] > 0:
+                share = total[ja[icon]]
+                fraction[icon] = ustrf[n] / share if share > 0.0 else 0.0
+
+    ndiv = optional("NDIV", 0, nreach)
+
+    return {
+        "reach_ddischarge": ddischarge,
+        "reach_depth": depth,
+        "reach_discharge": discharge,
+        "reach_fraction": fraction,
+        "reach_has_section": has_section,
+        "reach_flow_limited": flow_limited,
+        "reach_ia": ia,
+        "reach_idir": idir,
+        "reach_is_free": is_free,
+        "reach_ja": ja,
+        "reach_ndiv": ndiv,
+    }
+
+
+class SfrCoupling:
+    """The reach rows of the bordered adjoint system.
+
+    One instance follows a performance measure through its backward sweep. A
+    reach carries no storage, so unlike a lake nothing is carried between time
+    steps; the routing is solved within each step.
+    """
+
+    def __init__(self, logger=None):
+        """Initialize the coupling.
+
+        Parameters
+        ----------
+        logger : object, optional
+            Logger used to report where a reach is only partly differentiated.
+        """
+        self.logger = logger
+        self.columns = {}
+        self._warned = set()
+
+    def reset_step(self) -> None:
+        """Forget the previous time step's reach state."""
+        self.columns = {}
+
+    def _warn(self, message: str) -> None:
+        if self.logger is not None:
+            self.logger.warning(message)
+
+    def _warn_once(self, pname: str, grp) -> None:
+        """Warn where a reach's routing is differentiated only in part."""
+        if pname in self._warned:
+            return
+        self._warned.add(pname)
+
+        if grp["reach_has_section"][:].max() > 0:
+            self._warn(
+                f"streamflow-routing package '{pname}' has reaches with a cross "
+                "section. Their discharge follows the section rather than a "
+                "power of the depth, and that derivative is not formed, so "
+                "those reaches keep a fixed stage and the sensitivity is "
+                "approximate."
+            )
+        if grp["reach_flow_limited"][:].max() > 0:
+            self._warn(
+                f"streamflow-routing package '{pname}' has reaches that give up "
+                "all of the water they carry. Their leakage follows the reaches "
+                "above them rather than their own stage, and that coupling is "
+                "not formed, so the sensitivity is approximate."
+            )
+        if grp["reach_ndiv"][:].max() > 0:
+            self._warn(
+                f"streamflow-routing package '{pname}' has diversions. The flow "
+                "they take is not differentiated, so the sensitivity is "
+                "approximate."
+            )
+
+    def blocks(self, sol_dataset, gwf_package_dict) -> list:
+        """Return the reaches and the terms coupling them to the aquifer.
+
+        Returns
+        -------
+        list
+            One entry per streamflow-routing package. A reach that is dry, or
+            that follows a cross section, is left out.
+        """
+        found = []
+        for ptype, pnames in gwf_package_dict.items():
+            if ptype != "sfr6":
+                continue
+            for pname in pnames:
+                if pname not in sol_dataset:
+                    continue
+                grp = sol_dataset[pname]
+                if "reach_is_free" not in grp:
+                    continue
+                free = grp["reach_is_free"][:] == 1
+                if not free.any():
+                    continue
+
+                self._warn_once(pname, grp)
+
+                found.append(
+                    {
+                        "name": pname,
+                        "node": grp["nodelist"][:] - 1,
+                        "cond": grp["bound"][:, 1],
+                        "hcof": grp["hcof"][:],
+                        "ddischarge": grp["reach_ddischarge"][:],
+                        "fraction": grp["reach_fraction"][:],
+                        "free": free,
+                        "ia": grp["reach_ia"][:],
+                        "idir": grp["reach_idir"][:],
+                        "ja": grp["reach_ja"][:],
+                    }
+                )
+        return found
+
+    def dfds(self, entries, kk, blocks) -> dict:
+        """Return the derivative of the measure with respect to each reach depth.
+
+        A flux measure on a reach sums the exchange at the cells it names, and
+        that exchange depends on the reach stage as well as on the head.
+        """
+        result = {}
+        for block in blocks:
+            weights = {
+                pfr.inode: pfr.weight
+                for pfr in entries
+                if pfr.kperkstp == kk and pfr.pm_type == block["name"]
+            }
+            if not weights:
+                continue
+            for ireach in range(block["node"].shape[0]):
+                node = int(block["node"][ireach])
+                if node not in weights:
+                    continue
+                key = (block["name"], ireach)
+                result[key] = result.get(key, 0.0) + weights[node] * float(
+                    block["cond"][ireach]
+                )
+        return result
+
+    def augment(self, amat, rhs, blocks, dfds, nnodes):
+        """Border the adjoint system with the reach routing equations.
+
+        Returns
+        -------
+        tuple
+            The bordered matrix and the bordered right-hand side. The column
+            each free reach occupies is kept on the instance.
+        """
+        self.columns = {}
+        ireach = 0
+        for block in blocks:
+            for n in range(block["free"].shape[0]):
+                if block["free"][n]:
+                    self.columns[(block["name"], n)] = ireach
+                    ireach += 1
+        nreach = ireach
+
+        drds = sparse.lil_matrix((int(nnodes), int(nreach)))
+        drdh = sparse.lil_matrix((int(nreach), int(nnodes)))
+        drdr = sparse.lil_matrix((int(nreach), int(nreach)))
+
+        for block in blocks:
+            ia, ja, idir = block["ia"], block["ja"], block["idir"]
+            for n in range(block["free"].shape[0]):
+                key = (block["name"], n)
+                if key not in self.columns:
+                    continue
+                icol = self.columns[key]
+                node = int(block["node"][n])
+                cond = float(block["cond"][n])
+
+                # the aquifer sees the reach through its stage
+                drds[node, icol] += cond
+
+                # the reach equation: the Manning discharge against the mean of
+                # the flow in and out, so half of the leakage appears here
+                drdr[icol, icol] += float(block["ddischarge"][n]) + 0.5 * cond
+                drdh[icol, node] += 0.5 * float(block["hcof"][n])
+
+                # what this reach receives from the reaches above it
+                for icon in range(ia[n], ia[n + 1]):
+                    if idir[icon] <= 0:
+                        continue
+                    upstream = (block["name"], int(ja[icon]))
+                    if upstream not in self.columns:
+                        continue
+                    share = float(block["fraction"][icon])
+                    jcol = self.columns[upstream]
+                    iup = int(ja[icon])
+                    drdr[icol, jcol] -= share * float(block["ddischarge"][iup])
+                    drdr[icol, jcol] += 0.5 * share * float(block["cond"][iup])
+                    # the flow leaving the upstream reach carries half of its
+                    # leakage, so the head there enters with the same sign as
+                    # this reach's own
+                    upnode = int(block["node"][iup])
+                    drdh[icol, upnode] += 0.5 * share * float(block["hcof"][iup])
+
+        # amat is already transposed, so the reach blocks are transposed too
+        bordered = sparse.bmat(
+            [
+                [amat, drdh.transpose()],
+                [drds.transpose(), drdr.transpose()],
+            ],
+            format="csr",
+        )
+
+        rhs_reach = np.zeros(nreach)
+        for key, icol in self.columns.items():
+            rhs_reach[icol] = -dfds.get(key, 0.0)
+        return bordered, np.concatenate((rhs, rhs_reach))
+
+    def split(self, lamb, nnodes):
+        """Take the reach depths off the solution.
+
+        A reach carries no storage, so nothing is carried to the previous step.
+        """
+        return lamb[:nnodes]

--- a/mf6adj/advanced_packages/sfr.py
+++ b/mf6adj/advanced_packages/sfr.py
@@ -229,6 +229,7 @@ class SfrCoupling:
                         "cond": grp["bound"][:, 1],
                         "hcof": grp["hcof"][:],
                         "ddischarge": grp["reach_ddischarge"][:],
+                        "flow_limited": grp["reach_flow_limited"][:] == 1,
                         "fraction": grp["reach_fraction"][:],
                         "free": free,
                         "ia": grp["reach_ia"][:],
@@ -257,11 +258,70 @@ class SfrCoupling:
                 node = int(block["node"][ireach])
                 if node not in weights:
                     continue
+                if block["flow_limited"][ireach]:
+                    # this reach leaks the whole flow it receives, so the
+                    # measure follows the reaches above it
+                    for iup, share in self._upstream(block, ireach):
+                        ddepth, _ = self._outflow_derivatives(block, iup)
+                        key = (block["name"], iup)
+                        result[key] = (
+                            result.get(key, 0.0) + weights[node] * share * ddepth
+                        )
+                    continue
                 key = (block["name"], ireach)
                 result[key] = result.get(key, 0.0) + weights[node] * float(
                     block["cond"][ireach]
                 )
         return result
+
+    def _upstream(self, block, ireach):
+        """Yield the free reaches feeding a reach, with the share each sends."""
+        ia, ja, idir = block["ia"], block["ja"], block["idir"]
+        for icon in range(ia[ireach], ia[ireach + 1]):
+            if idir[icon] <= 0:
+                continue
+            iup = int(ja[icon])
+            if not block["free"][iup]:
+                # a reach that already gave up its whole flow sends nothing on
+                continue
+            yield iup, float(block["fraction"][icon])
+
+    def _outflow_derivatives(self, block, iup):
+        """Return how an upstream reach's outflow follows its depth and head.
+
+        The flow leaving a reach is its Manning discharge less half of its
+        leakage, so it follows the reach depth and the head beneath it.
+        """
+        ddepth = float(block["ddischarge"][iup]) - 0.5 * float(block["cond"][iup])
+        dhead = 0.5 * float(block["cond"][iup])
+        return ddepth, dhead
+
+    def measure_dfdh(self, entries, kk, blocks, nnodes):
+        """Return what a measure on a flow-limited reach adds to df/dh.
+
+        Such a reach leaks the whole flow it receives, so the measure follows
+        the head beneath the reaches above it rather than the head beneath the
+        reach itself.
+        """
+        extra = np.zeros(nnodes)
+        for block in blocks:
+            weights = {
+                pfr.inode: pfr.weight
+                for pfr in entries
+                if pfr.kperkstp == kk and pfr.pm_type == block["name"]
+            }
+            if not weights:
+                continue
+            for ireach in range(block["node"].shape[0]):
+                if not block["flow_limited"][ireach]:
+                    continue
+                node = int(block["node"][ireach])
+                if node not in weights:
+                    continue
+                for iup, share in self._upstream(block, ireach):
+                    _, dhead = self._outflow_derivatives(block, iup)
+                    extra[int(block["node"][iup])] += weights[node] * share * dhead
+        return extra
 
     def augment(self, amat, rhs, blocks, dfds, nnodes):
         """Border the adjoint system with the reach routing equations.
@@ -284,9 +344,26 @@ class SfrCoupling:
         drds = sparse.lil_matrix((int(nnodes), int(nreach)))
         drdh = sparse.lil_matrix((int(nreach), int(nnodes)))
         drdr = sparse.lil_matrix((int(nreach), int(nreach)))
+        # a reach that leaks the whole flow it receives ties one aquifer cell to
+        # another, so it corrects the flow matrix rather than the border
+        dgwf = sparse.lil_matrix((int(nnodes), int(nnodes)))
 
         for block in blocks:
             ia, ja, idir = block["ia"], block["ja"], block["idir"]
+
+            # a reach that gives up all of the water it carries leaks its own
+            # inflow, so the aquifer beneath it follows the reaches above
+            for n in range(block["free"].shape[0]):
+                if not block["flow_limited"][n]:
+                    continue
+                node = int(block["node"][n])
+                for iup, share in self._upstream(block, n):
+                    ddepth, dhead = self._outflow_derivatives(block, iup)
+                    upstream = (block["name"], iup)
+                    if upstream in self.columns:
+                        drds[node, self.columns[upstream]] += share * ddepth
+                    dgwf[node, int(block["node"][iup])] += share * dhead
+
             for n in range(block["free"].shape[0]):
                 key = (block["name"], n)
                 if key not in self.columns:
@@ -324,7 +401,7 @@ class SfrCoupling:
         # amat is already transposed, so the reach blocks are transposed too
         bordered = sparse.bmat(
             [
-                [amat, drdh.transpose()],
+                [amat + dgwf.transpose().tocsr(), drdh.transpose()],
                 [drds.transpose(), drdr.transpose()],
             ],
             format="csr",

--- a/mf6adj/pm.py
+++ b/mf6adj/pm.py
@@ -21,7 +21,7 @@ from scipy.sparse.linalg import (
     svds,
 )
 
-from .advanced_packages import LakeCoupling
+from .advanced_packages import LakeCoupling, SfrCoupling
 from .utils.utils import SolverCallback
 from .utils.utils_fileio import _write_group_to_hdf
 from .utils.utils_logger import _LoggerUtil
@@ -182,6 +182,7 @@ class PerfMeas:
         self._name = pm_name.lower().strip()
         self._entries = pm_entries
         self._lake = None
+        self._sfr = None
 
         if logger is None:
             logger_name = f"{self.__class__.__name__}-{self.name}"
@@ -635,6 +636,7 @@ class PerfMeas:
         # scalar for slicing the bordered solution.
         nnode = int(np.asarray(nnodes).ravel()[0])
         self._lake = LakeCoupling(logger=self.logger.logger)
+        self._sfr = SfrCoupling(logger=self.logger.logger)
 
         bnd_dict = get_mf6_bound_dict()
         comp_bnd_results = {}
@@ -733,8 +735,6 @@ class PerfMeas:
             lake_blocks = self._lake.blocks(hdf[sol_key], gwf_package_dict)
             if not lake_blocks:
                 self._lake.reset_step()
-                if lamb.shape[0] != nnode:
-                    lamb = lamb[:nnode]
             else:
                 dt = float(hdf[sol_key].attrs["dt"])
                 amat, rhs = self._lake.augment(
@@ -746,12 +746,27 @@ class PerfMeas:
                     nnode,
                     transient=lake_storage,
                 )
-                # the number of free lakes can change between steps, so rebuild
-                # the initial guess from the aquifer part and zero the rest
-                if lamb.shape[0] != amat.shape[0]:
-                    guess = np.zeros(amat.shape[0])
-                    guess[:nnode] = lamb[:nnode]
-                    lamb = guess
+
+            # the reach rows sit outside the lake rows, so they are added to
+            # whatever the lake left, and index the aquifer nodes below it
+            sfr_blocks = self._sfr.blocks(hdf[sol_key], gwf_package_dict)
+            if not sfr_blocks:
+                self._sfr.reset_step()
+            else:
+                amat, rhs = self._sfr.augment(
+                    amat,
+                    rhs,
+                    sfr_blocks,
+                    self._sfr.dfds(self._entries, kk, sfr_blocks),
+                    amat.shape[0],
+                )
+
+            # the number of free lakes and reaches can change between steps, so
+            # rebuild the initial guess from the aquifer part and zero the rest
+            if lamb.shape[0] != amat.shape[0]:
+                guess = np.zeros(amat.shape[0])
+                guess[:nnode] = lamb[:nnode]
+                lamb = guess
             self.logger.logger.debug(
                 (
                     "Transpose of amat took: "
@@ -989,6 +1004,9 @@ class PerfMeas:
                 elif info > 0:
                     self.logger.logger.warning("Solver convergence not achieved")
 
+            if self._sfr.columns:
+                # the reach depths come off first, being the outer border
+                lamb = self._sfr.split(lamb, lamb.shape[0] - len(self._sfr.columns))
             if self._lake.columns:
                 # split the lake stages off and carry their storage back to the
                 # previous time step, as drhsdh does for the aquifer

--- a/mf6adj/pm.py
+++ b/mf6adj/pm.py
@@ -753,6 +753,11 @@ class PerfMeas:
             if not sfr_blocks:
                 self._sfr.reset_step()
             else:
+                # a measure on a reach that leaks its whole flow follows the
+                # head beneath the reaches above it, which df/dh has to carry
+                rhs = rhs - self._sfr.measure_dfdh(
+                    self._entries, kk, sfr_blocks, rhs.shape[0]
+                )
                 amat, rhs = self._sfr.augment(
                     amat,
                     rhs,


### PR DESCRIPTION
Second half of #78, after #80 did the lake. A reach stage follows the flow through the reach, so holding it fixed returns a partial derivative. This solves the reach routing equations together with the flow equations.

## The rating

MODFLOW sets a reach depth so the Manning discharge equals the mean of the flow entering and leaving it:

```
qman(d) = (Q_in + Q_out) / 2,     Q_out = Q_in - leak
```

confirmed against MODFLOW to 6e-10 across every reach. For a reach without a cross section `calc_perimeter_wet` returns the reach width with no depth dependence (`gwf-sfr.f90`), so the hydraulic radius is the depth and the discharge is a clean 5/3 power of it. The derivative is that exponent times the discharge over the depth, taken from the discharge MODFLOW reports rather than by rebuilding the rating, so no unit conversion is carried.

This is worth stating because the empirical exponent looks like 1.84, not 5/3. The depth sets the leakage, which changes the flow, so a fitted (depth, flow) pair is an equilibrium of the coupled system rather than a point on the rating.

## What changes

The adjoint system is bordered with one equation per reach, carrying the routing:

```
dR_r/dd_r        = dqman/dd|_r + cond_r / 2
dR_r/dd_upstream = -share * (dqman/dd|_u - cond_u / 2)
dR_r/dh_r        = hcof_r / 2
dR_gwf/dd_r      = cond_r
```

Half of the leakage appears in the reach equation because the rating is against the mean flow, and the flow leaving an upstream reach carries half of that reach's leakage.

A reach that gives up all of the water it carries leaks its own inflow rather than a head-dependent amount, which MODFLOW marks by leaving `hcof` at zero while the reach still holds water. Its leakage follows the reaches above it, so it reaches the aquifer through their depths and through the heads beneath them, and a measure on it follows the same terms. The head term ties one aquifer cell to another, so it corrects the flow matrix rather than the border.

The reach rows sit outside the lake rows, so a model with both gets one combined system. A reach carries no storage, so unlike a lake nothing is carried between time steps.

## Verification

Every case compares against a finite-difference total derivative.

| case | before | after |
| --- | --- | --- |
| steep, shallow stream | 1.0105 | 1.0000 |
| slow, deep stream | 1.2581 | 1.0004 |
| fully losing stream | -2.19e-1 against ~0 | 1.5e-16 against -1.4e-10 |

Removing the reach equations returns the deep case to a quarter out, and removing the flow-limited coupling returns the losing case to -2.19e-1, so the tests detect the change rather than merely passing.

The frozen-stage error tracks how far the stage moves: about a percent for a steep, shallow stream and a quarter for a slow, deep one. The synthetic valley training model has a slope of 0.1 and depths under a tenth of a foot, so its streamflow capture barely moves, from -0.52386 to -0.52294.

Full suite locally: 39 passed, 1 skipped, including the sagehen and sanpedro SFR models.

## What is not covered

- Reaches with a cross section follow `get_mannings_section` rather than a power of the depth, so the 5/3 derivative does not hold. Those reaches keep a fixed stage and are reported as a warning.
- Diversions are not differentiated, and are reported as a warning.
- `test_sfr_fully_losing` detects the flow-limited coupling as a whole, but not the Jacobian part on its own: every reach in it is measured, so the measure derivative carries the result. A head measure away from the stream would separate them.

With this in, #78 can close.
