### PR TITLE
fix(pm): drop drain entries sitting on their activation threshold

### DIFF
--- a/autotest/test_drn_corner.py
+++ b/autotest/test_drn_corner.py
@@ -19,10 +19,17 @@ Cases:
                                   for any tolerance.
 """
 
+import pathlib as pl
+import sys
+
 import numpy as np
 import pytest
 
-from mf6adj.boundary import drain_corner_entries, drop_corner_entries
+try:
+    from mf6adj.boundary import drain_corner_entries, drop_corner_entries
+except ImportError:
+    sys.path.insert(0, str(pl.Path("../").resolve()))
+    from mf6adj.boundary import drain_corner_entries, drop_corner_entries
 
 
 class FakeGroup(dict):

--- a/autotest/test_drn_corner.py
+++ b/autotest/test_drn_corner.py
@@ -1,0 +1,94 @@
+"""
+Tests for drains sitting on the corner of the drain flow function.
+
+A drain without a drainage depth switches on and off at its elevation, and a
+converged solution leaves drains sitting exactly there because a drain pins the
+head at its elevation. The derivative is minus the conductance from above and
+zero from below, so crediting the measure with the conductance makes the adjoint
+state unbounded.
+
+Cases:
+  - test_corner_mask            : only active entries within the tolerance of
+                                  their elevation are selected, and a zero
+                                  tolerance disables the check.
+  - test_drop_corner_entries    : a corner entry is zeroed, a discharging entry
+                                  is kept, and the original array is unchanged.
+  - test_group_without_elevation: a package with no elevation, such as general
+                                  head, is left alone.
+  - test_corner_is_scale_free   : a drain exactly on its elevation is dropped
+                                  for any tolerance.
+"""
+
+import numpy as np
+import pytest
+
+from mf6adj.boundary import drain_corner_entries, drop_corner_entries
+
+
+class FakeGroup(dict):
+    """Stand-in for a forward-solution package group."""
+
+    def __contains__(self, key):
+        return dict.__contains__(self, key)
+
+
+def _group(nodelist, hcof, elev):
+    return FakeGroup(
+        nodelist=np.array(nodelist, dtype=int),
+        hcof=np.array(hcof, dtype=float),
+        elev=np.array(elev, dtype=float),
+    )
+
+
+def test_corner_mask():
+    """Only active entries within the tolerance of their elevation are selected."""
+    # one drain on the corner, one discharging, one already inactive
+    group = _group(
+        nodelist=[1, 2, 3], hcof=[-100.0, -100.0, 0.0], elev=[10.0, 10.0, 10.0]
+    )
+    head = np.array([10.0 + 1.0e-12, 12.0, 5.0])
+
+    mask = drain_corner_entries(group, head, tol=1.0e-6)
+    assert mask.tolist() == [True, False, False]
+
+    # a zero criterion disables the check
+    mask = drain_corner_entries(group, head, tol=0.0)
+    assert not mask.any()
+
+
+def test_drop_corner_entries():
+    """The corner entry is zeroed and the discharging entry is untouched."""
+    group = _group(nodelist=[1, 2], hcof=[-100.0, -250.0], elev=[10.0, 10.0])
+    head = np.array([10.0 + 1.0e-12, 12.0])
+
+    hcof, ncorner = drop_corner_entries(group, group["hcof"], head, 1.0e-6)
+    assert ncorner == 1
+    assert hcof.tolist() == [0.0, -250.0]
+
+    # the original array is not modified in place
+    assert group["hcof"].tolist() == [-100.0, -250.0]
+
+    hcof, ncorner = drop_corner_entries(group, group["hcof"], head, 0.0)
+    assert ncorner == 0
+
+
+def test_group_without_elevation():
+    """A package with no elevation, such as general head, is left alone."""
+    group = FakeGroup(
+        nodelist=np.array([1, 2]),
+        hcof=np.array([-100.0, -250.0]),
+        bhead=np.array([10.0, 10.0]),
+    )
+    head = np.array([10.0, 10.0])
+    hcof, ncorner = drop_corner_entries(group, group["hcof"], head, 1.0e-6)
+    assert ncorner == 0
+    assert hcof.tolist() == [-100.0, -250.0]
+
+
+@pytest.mark.parametrize("tol", [1.0e-9, 1.0e-6, 1.0e-4])
+def test_corner_is_scale_free(tol):
+    """A drain exactly on its elevation is dropped for any criterion."""
+    group = _group(nodelist=[1], hcof=[-3339.77], elev=[336.59])
+    head = np.array([336.59])
+    mask = drain_corner_entries(group, head, tol)
+    assert mask.tolist() == [True]

--- a/mf6adj/adj.py
+++ b/mf6adj/adj.py
@@ -14,6 +14,7 @@ import pandas as pd
 from xmipy.errors import XMIError
 
 from .advanced_packages import lake_forward_terms, sfr_forward_terms
+from .boundary import DRAIN_CORNER_TOL
 from .pm import PerfMeas, PerfMeasRecord
 from .utils.utils import _utils_cd
 from .utils.utils_fileio import _write_group_to_hdf
@@ -960,6 +961,7 @@ class Mf6Adj:
         dvclose: Optional[float] = 1e-6,
         rclose: Optional[float] = 1e-3,
         dvscale: bool = False,
+        drain_corner_tol: float = DRAIN_CORNER_TOL,
     ) -> dict[str, pd.DataFrame]:
         """Solve for the adjoint state, one performance measure at a time.
 
@@ -1001,6 +1003,11 @@ class Mf6Adj:
         dvscale : bool, optional
             Scale lambda and the right-hand side to improve iterative solver
             convergence for large lambda values.
+        drain_corner_tol : float, optional
+            Head above a drain elevation below which the entry is treated as
+            sitting on the corner of the drain flow function and dropped from
+            the performance-measure derivative. A value of zero disables the
+            check.
 
         Returns
         -------
@@ -1037,6 +1044,7 @@ class Mf6Adj:
                     dvclose=dvclose,
                     rclose=rclose,
                     dvscale=dvscale,
+                    drain_corner_tol=drain_corner_tol,
                 )
                 dfs[pm.name] = df
         return dfs

--- a/mf6adj/boundary.py
+++ b/mf6adj/boundary.py
@@ -1,0 +1,70 @@
+"""Head-dependent boundaries whose flow has a corner at a threshold.
+
+A drain without a drainage depth switches on and off at its elevation, so its
+flow is not differentiable there. The derivative is minus the conductance
+approaching from above and zero approaching from below, and a converged solution
+leaves drains sitting on that corner because a drain pins the head at its
+elevation.
+"""
+
+import numpy as np
+
+DRAIN_CORNER_TOL = 1.0e-6
+"""Default head above a drain elevation below which the entry is on the corner."""
+
+
+def drain_corner_entries(group, head, tol=DRAIN_CORNER_TOL):
+    """Return the drain entries whose activation state is unresolved.
+
+    Parameters
+    ----------
+    group : h5py.Group
+        Forward-solution group for one drain package.
+    head : ndarray
+        Simulated head for every node.
+    tol : float, optional
+        Head above the drain elevation below which the entry is on the corner.
+        A value of zero disables the check.
+
+    Returns
+    -------
+    ndarray
+        Boolean mask, true where the entry sits on the corner.
+    """
+    if tol <= 0.0 or "elev" not in group:
+        return np.zeros(group["hcof"].shape[0], dtype=bool)
+
+    nodes = group["nodelist"][:] - 1
+    hcof = group["hcof"][:]
+    above = head[nodes] - group["elev"][:]
+    # an active drain this close to its elevation carries no flow and turns off
+    # under any drawdown, so its conductance is not a defensible derivative
+    return (hcof != 0.0) & (above <= tol)
+
+
+def drop_corner_entries(group, hcof, head, tol=DRAIN_CORNER_TOL):
+    """Zero the drain entries that sit on the corner.
+
+    Parameters
+    ----------
+    group : h5py.Group
+        Forward-solution group for one drain package.
+    hcof : ndarray
+        Boundary hcof for the package.
+    head : ndarray
+        Simulated head for every node.
+    tol : float, optional
+        Head above the drain elevation below which the entry is on the corner.
+
+    Returns
+    -------
+    tuple[ndarray, int]
+        Adjusted hcof and the number of entries that were zeroed.
+    """
+    corner = drain_corner_entries(group, head, tol)
+    ncorner = int(corner.sum())
+    if ncorner == 0:
+        return hcof, 0
+    adjusted = hcof.copy()
+    adjusted[corner] = 0.0
+    return adjusted, ncorner

--- a/mf6adj/pm.py
+++ b/mf6adj/pm.py
@@ -22,6 +22,7 @@ from scipy.sparse.linalg import (
 )
 
 from .advanced_packages import LakeCoupling, SfrCoupling
+from .boundary import DRAIN_CORNER_TOL, drop_corner_entries
 from .utils.utils import SolverCallback
 from .utils.utils_fileio import _write_group_to_hdf
 from .utils.utils_logger import _LoggerUtil
@@ -433,6 +434,7 @@ class PerfMeas:
         dvclose: Optional[float] = 1e-6,
         rclose: Optional[float] = 1e-3,
         dvscale: bool = False,
+        drain_corner_tol: float = DRAIN_CORNER_TOL,
     ) -> pd.DataFrame:
         """Solve for the adjoint state for the performance measure.
 
@@ -482,6 +484,11 @@ class PerfMeas:
         dvscale : bool, optional
             Scale lambda and the right-hand side to improve iterative solver
             convergence for large lambda values.
+        drain_corner_tol : float, optional
+            Head above a drain elevation below which the entry is treated as
+            sitting on the corner of the drain flow function and dropped from
+            the performance-measure derivative. A value of zero disables the
+            check.
 
         Returns
         -------
@@ -675,7 +682,7 @@ class PerfMeas:
             self.logger.logger.debug("Forming rhs")
 
             self.logger.logger.debug("Calculate dfdh")
-            dfdh = self.__dfdh(kk, hdf[sol_key])
+            dfdh = self.__dfdh(kk, hdf[sol_key], tol=drain_corner_tol)
 
             self.logger.logger.debug(
                 "Calculating dfdh took: "
@@ -1656,7 +1663,7 @@ class PerfMeas:
         relevant_entries = [p for p in self._entries if p.kperkstp == kk]
         return len(relevant_entries) > 0
 
-    def __dfdh(self, kk, sol_dataset) -> np.ndarray:
+    def __dfdh(self, kk, sol_dataset, tol=DRAIN_CORNER_TOL) -> np.ndarray:
         """Return the derivative of the performance measure with respect to head.
 
         Parameters
@@ -1667,6 +1674,9 @@ class PerfMeas:
             Forward-solution HDF5 group for one time step. The group must
             contain a ``head`` dataset and, for flux performance measures,
             package subgroups with ``nodelist`` and ``hcof`` datasets.
+        tol : float, optional
+            Head above a drain elevation below which the entry is treated as
+            sitting on the corner and dropped from the derivative.
 
         Returns
         -------
@@ -1699,6 +1709,17 @@ class PerfMeas:
                 if pfr.pm_type not in cached_maps:
                     hcof = sol_dataset[pfr.pm_type]["hcof"][:]
                     nodes = sol_dataset[pfr.pm_type]["nodelist"][:] - 1
+                    # a drain on its corner has no defensible derivative, so
+                    # it contributes nothing to the measure
+                    hcof, ncorner = drop_corner_entries(
+                        sol_dataset[pfr.pm_type], hcof, head, tol
+                    )
+                    if ncorner > 0:
+                        self.logger.logger.warning(
+                            f"{pfr.pm_type}: dropped {ncorner} drain entries "
+                            + f"within {tol:g} of their elevation from the "
+                            + "performance measure derivative"
+                        )
                     # A cell can carry more than one boundary from the same
                     # package - a lake connected both vertically and
                     # horizontally to it - and the measure sums the flow through


### PR DESCRIPTION
A drain without a drainage depth switches on and off at its elevation, so its
flow has a corner there, and a converged solution leaves drains sitting on it
because a drain pins the head at its elevation. The performance-measure
derivative took the full conductance regardless, which left the adjoint state
unbounded and produced capture fractions above one. Drain entries within
`drain_corner_tol` of their elevation are now dropped from the derivative.

On a 2.45 million cell model the largest capture fraction goes from 63.5 with
346 cells above one to 1.0 with none, and 55 of 347731 active drain entries are
dropped.

Closes #83
