### PR TITLE
fix(adj): select the storage terms the way MODFLOW 6 does

### DIFF
--- a/autotest/test_sto.py
+++ b/autotest/test_sto.py
@@ -1,0 +1,166 @@
+"""
+Tests for the storage terms that couple one time step to the next.
+
+MODFLOW 6 selects between the specific-storage and specific-yield terms on the
+cell saturation, and under SS_CONFINED_ONLY it drops the specific-storage term
+entirely for a cell that is not full rather than scaling it. The adjoint has to
+make the same selection or the sensitivity carries a storage term the forward
+model does not have.
+
+Cases:
+  - test_storage_sensitivity[confined_only] : SS_CONFINED_ONLY, partially
+                                              saturated cells, adjoint matches a
+                                              finite-difference derivative.
+  - test_storage_sensitivity[default]       : the same for the default specific
+                                              storage formulation.
+  - test_confined_only_drops_partial_cells  : the specific-storage term is
+                                              dropped where the cell was not
+                                              full, and kept where it was.
+"""
+
+import pathlib as pl
+import shutil
+import sys
+
+import flopy
+import h5py
+import numpy as np
+import pytest
+
+try:
+    import mf6adj
+except ImportError:
+    sys.path.insert(0, str(pl.Path("../").resolve()))
+    import mf6adj
+
+mf6_bin, lib_name = mf6adj.get_conda_mf6_paths()
+
+NAME = "sto"
+NROW = NCOL = 7
+TOP, BOTM = 10.0, 0.0
+WELL_CELL = (0, 3, 3)
+OBS_CELL = (0, 1, 1)
+WELL_RATE = -60.0
+NSTP = 4
+
+
+def _build_model(ws, rate, confined_only):
+    """A partially saturated transient model driven by one well."""
+    ws = pl.Path(ws)
+    if ws.exists():
+        shutil.rmtree(ws)
+    ws.mkdir(parents=True)
+    sim = flopy.mf6.MFSimulation(sim_name=NAME, sim_ws=str(ws), exe_name=mf6_bin)
+    # several steps, so the saturation carried between them actually changes
+    flopy.mf6.ModflowTdis(sim, nper=1, perioddata=[(400.0, NSTP, 1.0)])
+    flopy.mf6.ModflowIms(
+        sim,
+        complexity="complex",
+        outer_dvclose=1e-9,
+        inner_dvclose=1e-10,
+        outer_maximum=200,
+    )
+    gwf = flopy.mf6.ModflowGwf(
+        sim, modelname=NAME, newtonoptions="NEWTON", save_flows=True
+    )
+    flopy.mf6.ModflowGwfdis(
+        gwf, nlay=1, nrow=NROW, ncol=NCOL, delr=100.0, delc=100.0, top=TOP, botm=BOTM
+    )
+    flopy.mf6.ModflowGwfic(gwf, strt=8.0)
+    flopy.mf6.ModflowGwfnpf(gwf, icelltype=1, k=1.0)
+    kwargs = {"iconvert": 1, "ss": 1.0e-3, "sy": 0.2, "transient": {0: True}}
+    if confined_only:
+        kwargs["ss_confined_only"] = True
+    flopy.mf6.ModflowGwfsto(gwf, **kwargs)
+    flopy.mf6.ModflowGwfghb(
+        gwf,
+        stress_period_data=[[(0, i, 0), 8.0, 50.0] for i in range(NROW)],
+        pname="ghb-1",
+    )
+    flopy.mf6.ModflowGwfwel(gwf, stress_period_data=[[WELL_CELL, rate]], pname="wel-1")
+    flopy.mf6.ModflowGwfoc(
+        gwf,
+        head_filerecord=f"{NAME}.hds",
+        budget_filerecord=f"{NAME}.cbc",
+        saverecord=[("HEAD", "ALL"), ("BUDGET", "ALL")],
+    )
+    sim.write_simulation(silent=True)
+    success, buff = sim.run_simulation(silent=True)
+    assert success, "\n".join(buff[-15:])
+    return ws
+
+
+def _final_head(ws):
+    head = flopy.utils.HeadFile(pl.Path(ws) / f"{NAME}.hds")
+    return float(head.get_data(kstpkper=head.get_kstpkper()[-1])[OBS_CELL])
+
+
+def _solve_adjoint(ws):
+    """Sensitivity of the final head at the observation cell to the well rate."""
+    ws = pl.Path(ws)
+    k, i, j = OBS_CELL
+    with open(ws / "pm.dat", "w") as f:
+        f.write("begin performance_measure obs\n")
+        f.write(f"  1 {NSTP} {k + 1} {i + 1} {j + 1} head direct 1.0 -1.0e+30\n")
+        f.write("end performance_measure\n\n")
+    adj = mf6adj.Mf6Adj(
+        "pm.dat", lib_name, logging_level="WARNING", working_directory=str(ws)
+    )
+    adj.solve_forward_model(hdf5_name="fwd.hd5")
+    adj.solve_adjoint()
+    adj.finalize()
+    with h5py.File(ws / "adjoint_solution_obs.hd5", "r") as hf:
+        return float(hf["composite"]["wel6_q"][WELL_CELL])
+
+
+@pytest.mark.parametrize(
+    "confined_only", [True, False], ids=["confined_only", "default"]
+)
+def test_storage_sensitivity(function_tmpdir, confined_only):
+    """The adjoint matches a finite-difference derivative in a drained cell."""
+    dq = -3.0  # small enough to stay in the linear range
+
+    base_ws = _build_model(function_tmpdir / "base", WELL_RATE, confined_only)
+    pert_ws = _build_model(function_tmpdir / "pert", WELL_RATE + dq, confined_only)
+    finite_difference = (_final_head(pert_ws) - _final_head(base_ws)) / dq
+
+    # the cells must be partly drained, or the two formulations agree trivially
+    head = flopy.utils.HeadFile(base_ws / f"{NAME}.hds").get_data()
+    saturation = np.clip((head - BOTM) / (TOP - BOTM), 0.0, 1.0)
+    assert saturation.max() < 0.99, "the model has to leave cells partly drained"
+
+    adjoint = _solve_adjoint(base_ws)
+    assert np.isclose(adjoint, finite_difference, rtol=2e-2), (
+        f"adjoint {adjoint:.6e} does not match the finite-difference "
+        f"derivative {finite_difference:.6e}"
+    )
+
+
+def test_confined_only_drops_partial_cells(function_tmpdir):
+    """SS_CONFINED_ONLY drops the specific-storage term below full saturation."""
+    ws = _build_model(function_tmpdir / "run", WELL_RATE, True)
+    k, i, j = OBS_CELL
+    with open(ws / "pm.dat", "w") as f:
+        f.write("begin performance_measure obs\n")
+        f.write(f"  1 {NSTP} {k + 1} {i + 1} {j + 1} head direct 1.0 -1.0e+30\n")
+        f.write("end performance_measure\n\n")
+    adj = mf6adj.Mf6Adj(
+        "pm.dat", lib_name, logging_level="WARNING", working_directory=str(ws)
+    )
+    adj.solve_forward_model(hdf5_name="fwd.hd5")
+    adj.finalize()
+
+    with h5py.File(ws / "fwd.hd5", "r") as hf:
+        key = next(k for k in hf if k.startswith("solution_"))
+        drhsdh = hf[key]["drhsdh"][:]
+        sat = hf[key]["sat"][:]
+
+    area, sy = 100.0 * 100.0, 0.2
+    dt = 400.0 / NSTP
+    partial = sat < 1.0
+    assert partial.any(), "the model has to leave cells partly drained"
+    # below full saturation only the specific-yield term survives
+    expected = -area * sy / dt
+    assert np.allclose(drhsdh[partial], expected, rtol=1e-8), (
+        "specific storage is still applied where MODFLOW 6 drops it"
+    )

--- a/mf6adj/adj.py
+++ b/mf6adj/adj.py
@@ -476,11 +476,12 @@ class Mf6Adj:
         dt: float,
         sat_old: np.ndarray,
     ) -> np.ndarray:
-        """Return the head derivative of the storage-related right-hand side.
+        """Return the previous-head derivative of the storage right-hand side.
 
-        The derivative combines confined-storage and specific-yield terms for
-        the previous time step. Specific-yield contributions are suppressed in
-        fully saturated cells.
+        The storage right-hand side depends on the previous head through both
+        the head itself and the saturation it sets, and MODFLOW 6 selects
+        between the specific-storage and specific-yield terms on that
+        saturation. See SsTerms and SyTerms in GwfStorageUtils.f90.
 
         Parameters
         ----------
@@ -493,27 +494,51 @@ class Mf6Adj:
         -------
         ndarray
             Per-cell derivative of the storage-related right-hand side with
-            respect to head.
+            respect to the previous head.
         """
         area = get_ptr_from_gwf(self._gwf_name, "DIS", "AREA", self._gwf)
-
-        # specific storage
         top = get_ptr_from_gwf(self._gwf_name, "DIS", "TOP", self._gwf)
         bot = get_ptr_from_gwf(self._gwf_name, "DIS", "BOT", self._gwf)
         storage = get_ptr_from_gwf(self._gwf_name, "STO", "SS", self._gwf)
-
-        # specific yield
         iconvert = get_ptr_from_gwf(self._gwf_name, "STO", "ICONVERT", self._gwf)
         sy = get_ptr_from_gwf(self._gwf_name, "STO", "SY", self._gwf)
+        iconf_ss = int(
+            np.asarray(
+                get_ptr_from_gwf(self._gwf_name, "STO", "ICONF_SS", self._gwf)
+            ).ravel()[0]
+        )
+        iorig_ss = int(
+            np.asarray(
+                get_ptr_from_gwf(self._gwf_name, "STO", "IORIG_SS", self._gwf)
+            ).ravel()[0]
+        )
+        if iorig_ss != 0:
+            self.logger.logger.warning(
+                "ORIGINAL_SPECIFIC_STORAGE is not supported; the storage "
+                + "sensitivity uses the current specific-storage formulation"
+            )
+
         sat_old_mod = sat_old.copy()
         sat_old_mod[iconvert == 0] = 1.0
-        sy_mod = sy.copy()
-        sy_mod[sat_old_mod == 1.0] = 0.0
 
-        # calculate drhsdh
-        drhsdh = -1.0 * area * (storage * (top - bot) + sy_mod) / dt
+        # specific storage, rho1old in SsTerms
+        ss_term = area * storage * (top - bot) / dt
+        if iconf_ss != 0:
+            # SS_CONFINED_ONLY carries a previous-head term only where the cell
+            # was full; elsewhere the term is dropped rather than scaled
+            ss_scale = np.where(sat_old_mod == 1.0, 1.0, 0.0)
+        else:
+            # otherwise the term follows the previous saturation
+            ss_scale = sat_old_mod
+        # a cell that never converts is always full
+        ss_scale = np.where(iconvert == 0, 1.0, ss_scale)
 
-        return drhsdh
+        # specific yield, which enters only through the saturation and so
+        # vanishes once the cell is full or dry
+        sy_term = area * sy / dt
+        sy_scale = np.where((sat_old_mod > 0.0) & (sat_old_mod < 1.0), 1.0, 0.0)
+
+        return -1.0 * (ss_term * ss_scale + sy_term * sy_scale)
 
     def solve_forward_model(
         self,
@@ -775,6 +800,9 @@ class Mf6Adj:
                 data_dict["sat"] = sat
                 data_dict["sat_old"] = sat_old
 
+                # drhsdh stored here couples this time step to the next one, so
+                # the saturation it needs is this step's: the next step sees it
+                # as the old one. Do not move this below the calls.
                 sat_old = sat.copy()
                 if has_sto:  # has storage
                     dresdss_h = self._dresdss_h(head, head_old, dt1, sat, sat_old)


### PR DESCRIPTION
MODFLOW 6 chooses between the specific-storage and specific-yield terms on the
cell saturation, and under `SS_CONFINED_ONLY` it drops the specific-storage term
for a cell that is not full rather than scaling it. The adjoint applied specific
storage at full cell thickness everywhere, so a partially saturated cell carried
a storage term the forward model does not have.

On a partially saturated transient model the sensitivity error against a
finite-difference derivative falls from 10.7% to 0.17% with `SS_CONFINED_ONLY`,
and from 2.6% to 0.15% with the default formulation. The three tests added all
fail without the change.

`ORIGINAL_SPECIFIC_STORAGE` is reported as unsupported rather than silently
approximated: its previous-head derivative needs the previous head, which the
routine does not take.

Closes #85
