### PR TITLE
fix(pm): scale the recharge sensitivity by the cell area

### DIFF
--- a/autotest/test_rch.py
+++ b/autotest/test_rch.py
@@ -1,0 +1,132 @@
+"""
+Tests for the recharge sensitivity.
+
+MODFLOW 6 treats recharge as a rate over the cell area, so the flow a recharge
+value produces is the rate times the area and the sensitivity of a performance
+measure to it carries that area. A well rate is already a flow and does not.
+
+Cases:
+  - test_recharge_sensitivity      : the adjoint matches a finite-difference
+                                     derivative with respect to the recharge
+                                     rate.
+  - test_recharge_scales_with_area : the recharge sensitivity is the well
+                                     sensitivity times the cell area.
+"""
+
+import pathlib as pl
+import shutil
+import sys
+
+import flopy
+import h5py
+import numpy as np
+
+try:
+    import mf6adj
+except ImportError:
+    sys.path.insert(0, str(pl.Path("../").resolve()))
+    import mf6adj
+
+mf6_bin, lib_name = mf6adj.get_conda_mf6_paths()
+
+NAME = "rch"
+NROW = NCOL = 7
+DELRC = 250.0  # a cell area of 62500, far from 1.0
+CELL_AREA = DELRC * DELRC
+TOP, BOTM = 10.0, -20.0
+OBS_CELL = (0, 3, 3)
+BASE_RECHARGE = 1.0e-3
+
+
+def _build_model(ws, recharge):
+    ws = pl.Path(ws)
+    if ws.exists():
+        shutil.rmtree(ws)
+    ws.mkdir(parents=True)
+    sim = flopy.mf6.MFSimulation(sim_name=NAME, sim_ws=str(ws), exe_name=mf6_bin)
+    flopy.mf6.ModflowTdis(sim, nper=1, perioddata=[(1.0, 1, 1.0)])
+    flopy.mf6.ModflowIms(
+        sim, complexity="simple", outer_dvclose=1e-10, inner_dvclose=1e-11
+    )
+    gwf = flopy.mf6.ModflowGwf(sim, modelname=NAME, save_flows=True)
+    flopy.mf6.ModflowGwfdis(
+        gwf, nlay=1, nrow=NROW, ncol=NCOL, delr=DELRC, delc=DELRC, top=TOP, botm=BOTM
+    )
+    flopy.mf6.ModflowGwfic(gwf, strt=0.0)
+    flopy.mf6.ModflowGwfnpf(gwf, icelltype=0, k=10.0)
+    flopy.mf6.ModflowGwfghb(
+        gwf,
+        stress_period_data=[[(0, i, 0), 0.0, 100.0] for i in range(NROW)],
+        pname="ghb-1",
+    )
+    # a list recharge package, so the sensitivity is written as rch6_recharge
+    flopy.mf6.ModflowGwfrch(
+        gwf,
+        stress_period_data=[
+            [(0, i, j), recharge] for i in range(NROW) for j in range(NCOL)
+        ],
+        pname="rch-1",
+    )
+    flopy.mf6.ModflowGwfwel(gwf, stress_period_data=[[OBS_CELL, 0.0]], pname="wel-1")
+    flopy.mf6.ModflowGwfoc(
+        gwf,
+        head_filerecord=f"{NAME}.hds",
+        saverecord=[("HEAD", "ALL"), ("BUDGET", "ALL")],
+        budget_filerecord=f"{NAME}.cbc",
+    )
+    sim.write_simulation(silent=True)
+    success, buff = sim.run_simulation(silent=True)
+    assert success, "\n".join(buff[-15:])
+    return ws
+
+
+def _head(ws):
+    return float(flopy.utils.HeadFile(pl.Path(ws) / f"{NAME}.hds").get_data()[OBS_CELL])
+
+
+def _solve_adjoint(ws):
+    ws = pl.Path(ws)
+    k, i, j = OBS_CELL
+    with open(ws / "pm.dat", "w") as f:
+        f.write("begin performance_measure obs\n")
+        f.write(f"  1 1 {k + 1} {i + 1} {j + 1} head direct 1.0 -1.0e+30\n")
+        f.write("end performance_measure\n\n")
+    adj = mf6adj.Mf6Adj(
+        "pm.dat", lib_name, logging_level="WARNING", working_directory=str(ws)
+    )
+    adj.solve_forward_model(hdf5_name="fwd.hd5")
+    adj.solve_adjoint()
+    adj.finalize()
+    with h5py.File(ws / "adjoint_solution_obs.hd5", "r") as hf:
+        return (
+            hf["composite"]["rch6_recharge"][:].copy(),
+            hf["composite"]["wel6_q"][:].copy(),
+        )
+
+
+def test_recharge_sensitivity(function_tmpdir):
+    """The adjoint matches a finite difference in the recharge rate."""
+    dr = 1.0e-5
+
+    base_ws = _build_model(function_tmpdir / "base", BASE_RECHARGE)
+    pert_ws = _build_model(function_tmpdir / "pert", BASE_RECHARGE + dr)
+    # every cell is recharged, so the finite difference is the summed sensitivity
+    finite_difference = (_head(pert_ws) - _head(base_ws)) / dr
+
+    recharge_sens, _ = _solve_adjoint(base_ws)
+    adjoint = float(np.sum(recharge_sens))
+
+    assert np.isclose(adjoint, finite_difference, rtol=1e-3), (
+        f"adjoint {adjoint:.6e} does not match the finite-difference "
+        f"derivative {finite_difference:.6e}"
+    )
+
+
+def test_recharge_scales_with_area(function_tmpdir):
+    """The recharge sensitivity is the well sensitivity times the cell area."""
+    ws = _build_model(function_tmpdir / "run", BASE_RECHARGE)
+    recharge_sens, well_sens = _solve_adjoint(ws)
+
+    assert np.allclose(recharge_sens, well_sens * CELL_AREA, rtol=1e-10), (
+        "the recharge sensitivity does not carry the cell area"
+    )

--- a/mf6adj/pm.py
+++ b/mf6adj/pm.py
@@ -615,6 +615,7 @@ class PerfMeas:
         top = hdf["gwf_info"]["top"][:]
         bot = hdf["gwf_info"]["bot"][:]
         icelltype = hdf["gwf_info"]["icelltype"][:]
+        area = hdf["gwf_info"]["area"][:]
         ihighcellsat = hdf["gwf_info"]["ihighcellsat"][0]
 
         comp_k33_sens = np.zeros(nnodes)
@@ -1103,8 +1104,11 @@ class PerfMeas:
 
             data["wel6_q"] = lamb
             comp_welq_sens += lamb * w
-            comp_rch_sens += lamb * w
-            data["rch6_recharge"] = lamb
+            # a well rate is already a flow, but recharge is a rate over the
+            # cell area, so the flow it produces is recharge * area
+            rch_sens = lamb * area
+            comp_rch_sens += rch_sens * w
+            data["rch6_recharge"] = rch_sens
 
             for ptype, pnames in gwf_package_dict.items():
                 if ptype == "chd6":


### PR DESCRIPTION
MODFLOW 6 treats recharge as a rate over the cell area, so the flow a recharge
value produces is the rate times the area (`rch_cf` in `gwf-rch.f90`). The
sensitivity of a performance measure to recharge was reported as the adjoint
state alone, leaving it short by the cell area: a factor of 62500 on a 250 m
grid, and a varying factor on a grid with variable cell sizes.

A well rate is already a flow, so `wel6_q` is unchanged. Both tests added fail
without the change.

Closes #86
