### PR TITLE
feat(adj): report specific storage and specific yield separately

### DIFF
--- a/autotest/test_storage_parameters.py
+++ b/autotest/test_storage_parameters.py
@@ -1,0 +1,193 @@
+"""
+Tests the sensitivities to specific storage and to specific yield.
+
+Storage releases water in two ways, and a convertible cell uses both: specific
+storage as the head falls while the cell stays full, specific yield as the cell
+drains. They are separate parameters of the flow model, so they carry separate
+sensitivities, and each is checked here against a finite-difference derivative
+taken by perturbing that parameter alone.
+
+Cases:
+  - test_specific_storage_sensitivity : the reported ss sensitivity matches a
+                                        finite difference in ss.
+  - test_specific_yield_sensitivity   : the reported sy sensitivity matches a
+                                        finite difference in sy.
+  - test_sensitivities_are_separate   : perturbing one parameter leaves the
+                                        other one's finite difference alone,
+                                        so the two are not the same quantity.
+"""
+
+import pathlib as pl
+import shutil
+import sys
+
+import flopy
+import h5py
+import numpy as np
+import pytest
+
+try:
+    import mf6adj
+except ImportError:
+    sys.path.insert(0, str(pl.Path("../").resolve()))
+    import mf6adj
+
+mf6_bin, lib_name = mf6adj.get_conda_mf6_paths()
+
+NAME = "sto"
+NROW = NCOL = 7
+DELRC = 100.0
+TOP, BOTM = 10.0, 0.0
+WELL_CELL = (0, 3, 3)
+OBS_CELL = (0, 1, 1)
+WELL_RATE = -60.0
+NPER, NSTP, PERLEN = 1, 4, 400.0
+SS = 1.0e-3
+SY = 0.2
+
+
+def _build_model(ws, ss=SS, sy=SY, confined_only=False, strt=8.0):
+    """A partly drained aquifer, so both storage terms are active."""
+    ws = pl.Path(ws)
+    if ws.exists():
+        shutil.rmtree(ws)
+    ws.mkdir(parents=True)
+    sim = flopy.mf6.MFSimulation(sim_name=NAME, sim_ws=str(ws), exe_name=mf6_bin)
+    flopy.mf6.ModflowTdis(sim, nper=NPER, perioddata=[(PERLEN, NSTP, 1.0)])
+    flopy.mf6.ModflowIms(
+        sim,
+        complexity="complex",
+        outer_dvclose=1.0e-9,
+        inner_dvclose=1.0e-10,
+        outer_maximum=200,
+    )
+    gwf = flopy.mf6.ModflowGwf(
+        sim, modelname=NAME, newtonoptions="NEWTON", save_flows=True
+    )
+    flopy.mf6.ModflowGwfdis(
+        gwf, nlay=1, nrow=NROW, ncol=NCOL, delr=DELRC, delc=DELRC, top=TOP, botm=BOTM
+    )
+    flopy.mf6.ModflowGwfic(gwf, strt=strt)
+    flopy.mf6.ModflowGwfnpf(gwf, icelltype=1, k=1.0)
+    kwargs = {"iconvert": 1, "ss": ss, "sy": sy, "transient": {0: True}}
+    if confined_only:
+        kwargs["ss_confined_only"] = True
+    flopy.mf6.ModflowGwfsto(gwf, **kwargs)
+    flopy.mf6.ModflowGwfghb(
+        gwf,
+        stress_period_data=[[(0, i, 0), strt, 50.0] for i in range(NROW)],
+        pname="ghb-1",
+    )
+    flopy.mf6.ModflowGwfwel(
+        gwf, stress_period_data=[[WELL_CELL, WELL_RATE]], pname="wel-1"
+    )
+    flopy.mf6.ModflowGwfoc(
+        gwf,
+        head_filerecord=f"{NAME}.hds",
+        saverecord=[("HEAD", "ALL")],
+    )
+    sim.write_simulation(silent=True)
+    success, buff = sim.run_simulation(silent=True)
+    assert success, "\n".join(str(line) for line in buff[-20:])
+    return ws
+
+
+def _final_head(ws):
+    head = flopy.utils.HeadFile(pl.Path(ws) / f"{NAME}.hds")
+    return float(head.get_data(kstpkper=head.get_kstpkper()[-1])[OBS_CELL])
+
+
+def _solve_adjoint(ws):
+    """Sensitivities of the final head at the observation cell."""
+    ws = pl.Path(ws)
+    k, i, j = OBS_CELL
+    with open(ws / "pm.dat", "w") as f:
+        f.write("begin performance_measure obs\n")
+        f.write(f"  1 {NSTP} {k + 1} {i + 1} {j + 1} head direct 1.0 -1.0e+30\n")
+        f.write("end performance_measure\n\n")
+    adj = mf6adj.Mf6Adj(
+        "pm.dat", lib_name, logging_level="WARNING", working_directory=str(ws)
+    )
+    adj.solve_forward_model(hdf5_name="fwd.hd5")
+    adj.solve_adjoint()
+    adj.finalize()
+    with h5py.File(ws / "adjoint_solution_obs.hd5", "r") as hf:
+        return {name: hf["composite"][name][:].copy() for name in ("ss", "sy")}
+
+
+def _crosses_top(ws):
+    """True where the water level starts above the cell top and falls past it."""
+    head = flopy.utils.HeadFile(pl.Path(ws) / f"{NAME}.hds").get_alldata()
+    return bool((head >= TOP).any() and (head < TOP).any())
+
+
+def _drained(ws):
+    """True where the model leaves cells between full and dry."""
+    head = flopy.utils.HeadFile(pl.Path(ws) / f"{NAME}.hds").get_data()
+    saturation = np.clip((head - BOTM) / (TOP - BOTM), 0.0, 1.0)
+    return saturation.max() < 0.99 and saturation.min() > 0.01
+
+
+@pytest.mark.parametrize("parameter", ["ss", "sy"])
+@pytest.mark.parametrize(
+    "confined_only", [False, True], ids=["default", "confined_only"]
+)
+def test_storage_parameter_sensitivity(function_tmpdir, parameter, confined_only):
+    """Each storage sensitivity matches a finite difference in that parameter."""
+    fraction = 1.0e-3
+    tag = f"{parameter}_{int(confined_only)}"
+    # under SS_CONFINED_ONLY specific storage acts only while a cell is full, so
+    # the water level has to start above the top of the cell and fall past it
+    strt = 12.0 if confined_only else 8.0
+    base_ws = _build_model(
+        function_tmpdir / f"base_{tag}", confined_only=confined_only, strt=strt
+    )
+    assert _crosses_top(base_ws) if confined_only else _drained(base_ws), (
+        "the model has to exercise the saturation the option switches on"
+    )
+
+    if parameter == "ss":
+        step = SS * fraction
+        pert_ws = _build_model(
+            function_tmpdir / f"pert_{tag}",
+            ss=SS + step,
+            confined_only=confined_only,
+            strt=strt,
+        )
+    else:
+        step = SY * fraction
+        pert_ws = _build_model(
+            function_tmpdir / f"pert_{tag}",
+            sy=SY + step,
+            confined_only=confined_only,
+            strt=strt,
+        )
+    finite_difference = (_final_head(pert_ws) - _final_head(base_ws)) / step
+
+    # the parameter was changed in every cell, so compare the summed sensitivity
+    adjoint = float(np.sum(_solve_adjoint(base_ws)[parameter]))
+    assert np.isclose(adjoint, finite_difference, rtol=5.0e-2), (
+        f"the {parameter} sensitivity {adjoint:.6e} does not match the "
+        f"finite-difference derivative {finite_difference:.6e}"
+    )
+
+
+def test_sensitivities_are_separate(function_tmpdir):
+    """The two parameters move the head by different amounts."""
+    fraction = 1.0e-3
+    base_ws = _build_model(function_tmpdir / "base")
+    base_head = _final_head(base_ws)
+
+    ss_ws = _build_model(function_tmpdir / "ss", ss=SS * (1.0 + fraction))
+    sy_ws = _build_model(function_tmpdir / "sy", sy=SY * (1.0 + fraction))
+    from_ss = (_final_head(ss_ws) - base_head) / (SS * fraction)
+    from_sy = (_final_head(sy_ws) - base_head) / (SY * fraction)
+
+    assert not np.isclose(from_ss, from_sy, rtol=1.0e-2), (
+        "the model responds to the two storage parameters identically, so the "
+        "test cannot tell their sensitivities apart"
+    )
+    sensitivities = _solve_adjoint(base_ws)
+    assert not np.allclose(sensitivities["ss"], sensitivities["sy"], rtol=1.0e-6), (
+        "the reported ss and sy sensitivities are the same array"
+    )

--- a/mf6adj/adj.py
+++ b/mf6adj/adj.py
@@ -411,6 +411,28 @@ class Mf6Adj:
             logger=self.logger.logger,
         )
 
+    def _initial_saturation(self) -> np.ndarray:
+        """Return the saturation the initial heads imply.
+
+        Called before the first solve, where the saturation MODFLOW 6 reports is
+        the value it was allocated with rather than one computed from the heads.
+        """
+        head = self._gwf.get_value(
+            self._gwf.get_var_address("X", self._gwf_name.upper())
+        )
+        top = get_ptr_from_gwf(self._gwf_name, "DIS", "TOP", self._gwf)
+        bot = get_ptr_from_gwf(self._gwf_name, "DIS", "BOT", self._gwf)
+        head = np.asarray(head)[: top.shape[0]]
+
+        thickness = top - bot
+        saturation = np.ones_like(thickness, dtype=float)
+        wet = thickness > 0.0
+        saturation[wet] = np.clip((head[wet] - bot[wet]) / thickness[wet], 0.0, 1.0)
+        # a cell that never converts is full whatever its head
+        icelltype = get_ptr_from_gwf(self._gwf_name, "NPF", "ICELLTYPE", self._gwf)
+        saturation[icelltype == 0] = 1.0
+        return saturation
+
     def _dresdss_h(
         self,
         head: np.ndarray,
@@ -419,25 +441,28 @@ class Mf6Adj:
         sat: np.ndarray,
         sat_old: np.ndarray,
     ) -> np.ndarray:
-        """Return the storage contribution to the residual derivative.
+        """Return the specific-storage contribution to the residual derivative.
 
-        This term represents the derivative of the transient groundwater-flow
-        residual with respect to specific storage for the current time step. It
-        accounts for partially saturated conditions by forcing confined cells
-        (``ICONVERT == 0``) to remain fully saturated in the calculation.
+        The derivative of the transient groundwater flow residual with respect
+        to specific storage for one time step, taken over the saturations the
+        step starts and ends at. Under SS_CONFINED_ONLY specific storage acts
+        only while a cell is full, and the saturation is one at or above the top
+        of the cell and zero below it, so the derivative reduces to the terms of
+        the full cells. A cell that never converts is treated as full. See
+        SsTerms in GwfStorageUtils.f90.
 
         Parameters
         ----------
         head : ndarray
-            Current heads.
+            Head at the end of the step.
         head_old : ndarray
-            Heads from the previous solution step.
+            Head at the start of the step.
         dt : float
             Length of the current solution step in model time.
         sat : ndarray
-            Current saturation.
+            Saturation at the end of the step.
         sat_old : ndarray
-            Saturation from the previous solution step.
+            Saturation at the start of the step.
 
         Returns
         -------
@@ -457,18 +482,67 @@ class Mf6Adj:
         sat_old_mod[iconvert == 0] = 1.0
 
         height = top - bot
-
-        # result = np.zeros_like(head)
         dSC1 = area * height
-        result = (
-            (dSC1 / dt) * (sat_old_mod * head_old - sat_mod * head)
-            + (dSC1 / dt) * bot * (sat_mod - sat_old_mod)
-            + (dSC1 / (2.0 * dt)) * height * (sat_mod**2 - sat_old_mod**2)
+
+        iconf_ss = int(
+            np.asarray(
+                get_ptr_from_gwf(self._gwf_name, "STO", "ICONF_SS", self._gwf)
+            ).ravel()[0]
         )
+        if iconf_ss != 0:
+            # specific storage acts only while the cell is full, and the
+            # saturation is one at or above the top of the cell and zero below
+            full = sat_mod >= 1.0
+            full_old = sat_old_mod >= 1.0
+            result = (dSC1 / dt) * (
+                np.where(full, top - head, 0.0)
+                + np.where(full_old, head_old - top, 0.0)
+            )
+        else:
+            result = (
+                (dSC1 / dt) * (sat_old_mod * head_old - sat_mod * head)
+                + (dSC1 / dt) * bot * (sat_mod - sat_old_mod)
+                + (dSC1 / (2.0 * dt)) * height * (sat_mod**2 - sat_old_mod**2)
+            )
         # zero out dry cells
         result[head <= bot] = 0.0
         result[head_old <= bot] = 0.0
 
+        return result
+
+    def _dresdsy_h(
+        self,
+        dt: float,
+        sat: np.ndarray,
+        sat_old: np.ndarray,
+    ) -> np.ndarray:
+        """Return the specific-yield contribution to the residual derivative.
+
+        Specific yield releases the water a cell holds between the saturations
+        it starts and ends the time step at. See SyTerms in GwfStorageUtils.f90.
+
+        Parameters
+        ----------
+        dt : float
+            Length of the current solution step in model time.
+        sat : ndarray
+            Saturation at the end of the step.
+        sat_old : ndarray
+            Saturation at the start of the step.
+
+        Returns
+        -------
+        ndarray
+            Per-cell derivative of the residual with respect to specific yield.
+        """
+        top = get_ptr_from_gwf(self._gwf_name, "DIS", "TOP", self._gwf)
+        bot = get_ptr_from_gwf(self._gwf_name, "DIS", "BOT", self._gwf)
+        area = get_ptr_from_gwf(self._gwf_name, "DIS", "AREA", self._gwf)
+        iconvert = get_ptr_from_gwf(self._gwf_name, "STO", "ICONVERT", self._gwf)
+
+        result = area * (top - bot) * (sat_old - sat) / dt
+        # a cell that never converts stays full, so specific yield never acts
+        result[iconvert == 0] = 0.0
         return result
 
     def _drhsdh(
@@ -704,9 +778,10 @@ class Mf6Adj:
 
                 self._gwf.prepare_solve(1)
                 if sat_old is None:
-                    sat_old = self._gwf.get_value(
-                        self._gwf.get_var_address("SAT", self._gwf_name, "NPF")
-                    )
+                    # MODFLOW 6 has not filled the saturation for the first time
+                    # step yet, so it still holds the value it was allocated
+                    # with. Take the saturation the initial heads imply instead.
+                    sat_old = self._initial_saturation()
 
                 # solve until converged
                 while kiter < max_iter:
@@ -800,13 +875,18 @@ class Mf6Adj:
                 data_dict["sat"] = sat
                 data_dict["sat_old"] = sat_old
 
-                # drhsdh stored here couples this time step to the next one, so
-                # the saturation it needs is this step's: the next step sees it
-                # as the old one. Do not move this below the calls.
+                # The storage terms need two different saturations. A residual
+                # derivative belongs to this time step, so it takes the
+                # saturation the step started from. drhsdh couples this step to
+                # the next one, so it takes the saturation the step ended at,
+                # which the next step sees as the old one.
+                sat_prev = sat_old
                 sat_old = sat.copy()
                 if has_sto:  # has storage
-                    dresdss_h = self._dresdss_h(head, head_old, dt1, sat, sat_old)
+                    dresdss_h = self._dresdss_h(head, head_old, dt1, sat, sat_prev)
                     data_dict["dresdss_h"] = dresdss_h
+                    dresdsy_h = self._dresdsy_h(dt1, sat, sat_prev)
+                    data_dict["dresdsy_h"] = dresdsy_h
                     drhsdh = self._drhsdh(dt1, sat_old)
                     data_dict["drhsdh"] = drhsdh
                 else:

--- a/mf6adj/pm.py
+++ b/mf6adj/pm.py
@@ -621,10 +621,12 @@ class PerfMeas:
         comp_k33_sens = np.zeros(nnodes)
         comp_k_sens = np.zeros(nnodes)
         comp_ss_sens = None
+        comp_sy_sens = None
 
         has_sto = hdf[sol_keys[0]].attrs["has_sto"]
         if has_sto:
             comp_ss_sens = np.zeros(nnodes)
+            comp_sy_sens = np.zeros(nnodes)
 
         # An "instantaneous" measure looks at each time step on its own and
         # ignores how later time steps would otherwise feed back into earlier
@@ -1091,10 +1093,19 @@ class PerfMeas:
 
                 if iss == 0:
                     ss_sens = lamb * hdf[sol_key]["dresdss_h"][:]
+                    # written by solve_forward_model; an older forward file
+                    # carries only the specific-storage half
+                    if "dresdsy_h" in hdf[sol_key]:
+                        sy_sens = lamb * hdf[sol_key]["dresdsy_h"][:]
+                    else:
+                        sy_sens = np.zeros_like(lamb)
                 else:
                     ss_sens = np.zeros_like(lamb)
+                    sy_sens = np.zeros_like(lamb)
                 data["ss"] = ss_sens
+                data["sy"] = sy_sens
                 comp_ss_sens += ss_sens * w
+                comp_sy_sens += sy_sens * w
                 self.logger.logger.debug(
                     (
                         "Formulating storage took: "
@@ -1190,6 +1201,7 @@ class PerfMeas:
             comp_rch_sens /= wsum
             if has_sto:
                 comp_ss_sens /= wsum
+                comp_sy_sens /= wsum
             for name in comp_bnd_results:
                 comp_bnd_results[name] /= wsum
         data = {}
@@ -1198,6 +1210,7 @@ class PerfMeas:
 
         if has_sto:
             data["ss"] = comp_ss_sens
+            data["sy"] = comp_sy_sens
         data["wel6_q"] = comp_welq_sens
         data["rch6_recharge"] = comp_rch_sens
 
@@ -1230,6 +1243,7 @@ class PerfMeas:
             df[name] = vals
         if has_sto:
             df["ss"] = comp_ss_sens
+            df["sy"] = comp_sy_sens
 
         df.index.name = "node"
         if csv_summary:


### PR DESCRIPTION
Storage releases water in two ways, and a convertible cell uses both, but only a
specific-storage sensitivity was reported. A specific-yield sensitivity is added
beside it, and both are now taken over the saturations the time step starts and
ends at rather than over one of them twice.

## The saturation the first time step starts from

It was read before MODFLOW 6 had computed it, so it held the value the array was
allocated with, one, rather than the value the initial heads imply, which was
0.8 in the model used here. Nothing noticed, because the specific-storage
derivative was being handed the same saturation at both ends of the step and so
never read it. Only the first step was affected, and the error it introduced was
large enough to change the sign of the summed sensitivity once the derivative
started reading it.

## Against a finite difference in the parameter

| | before | after |
| --- | --- | --- |
| specific storage | 0.9844 | 1.0000 |
| specific yield | not reported | 1.0010 |

## SS_CONFINED_ONLY

Specific storage acts only while a cell is full. The saturation is then one at
or above the top of the cell and zero below it, and the two halves of the
derivative are taken on the saturations at each end of the step separately, so a
cell that is full at one end and not the other carries the half that applies.
The tests cover that case with a water level that starts above the top of the
cell and is drawn past it, and assert it does so, because a model whose cells
are never full makes the option vacuous and the case passes without testing
anything.

All five tests fail without the change; the specific-yield cases fail on a
missing output rather than a wrong number.
