### PR TITLE
feat(sfr): differentiate a reach with a cross section

### DIFF
--- a/autotest/test_sfr.py
+++ b/autotest/test_sfr.py
@@ -25,6 +25,8 @@ Cases:
                        vertical wall.
   - xs_derivative    : the derivative of that rating matches a central
                        difference through a break in the section.
+  - xs_negative_p    : a section whose wetted perimeter has gone negative, as
+                       MODFLOW lets it, still carries a leakage derivative.
   - sfr_cross_section: a stream whose reaches carry a cross section, whose
                        conductance follows the depth as well as the stage.
 """
@@ -46,7 +48,11 @@ except ImportError:
     sys.path.insert(0, str(pl.Path("../").resolve()))
     import mf6adj
 
-from mf6adj.advanced_packages.sfr_cross_section import mannings_section
+from mf6adj.advanced_packages.sfr import leakage_ratio
+from mf6adj.advanced_packages.sfr_cross_section import (
+    mannings_section,
+    wetted_perimeter,
+)
 
 mf6_bin, lib_name = mf6adj.get_conda_mf6_paths()
 
@@ -757,3 +763,34 @@ def test_sfr_cross_section(tmp_path):
     assert abs(adjoint - finite_difference) < 1.0e-3 * abs(finite_difference), (
         f"adjoint {adjoint} against a finite difference of {finite_difference}"
     )
+
+
+def test_xs_negative_perimeter():
+    """A section left with a negative perimeter still follows the depth.
+
+    MODFLOW subtracts the height of a vertical face standing above the water
+    surface, which can leave the wetted perimeter of a section negative. The
+    conductance is then negative rather than absent, and the leakage still
+    follows the depth through it.
+    """
+    # a tall wall over a short bank, so the face the water does not reach is
+    # longer than everything it does
+    station = np.array([0.0, 0.0, 0.1, 0.2])
+    heights = np.array([10.0, 5.0, 0.0, 5.0])
+    perimeter, dperimeter = wetted_perimeter(station, heights, 1.0)
+    assert perimeter < 0.0, f"expected a negative perimeter, got {perimeter}"
+
+    # a reach losing water, so the head difference across the streambed is
+    # positive whatever the sign of the conductance
+    cond = np.array([5.0 * 100.0 * perimeter / 1.0])
+    head_difference = 0.5
+    ratio = leakage_ratio(
+        np.array([perimeter]),
+        np.array([dperimeter]),
+        cond,
+        cond * head_difference,
+    )
+    expected = 1.0 + dperimeter / perimeter * head_difference
+    assert ratio[0] == pytest.approx(expected)
+    # the conductance alone would be the answer only if the section were flat
+    assert ratio[0] != pytest.approx(1.0)

--- a/autotest/test_sfr.py
+++ b/autotest/test_sfr.py
@@ -20,7 +20,9 @@ Cases:
   - branching        : a stream that splits sends its flow on in the shares the
                        reaches below it are given.
   - xs_rating        : the cross-section rating reproduces the discharge the
-                       forward model solved the reach depth against.
+                       forward model solved the reach depth against, for a
+                       channel with sloping banks and for one closed by a
+                       vertical wall.
   - xs_derivative    : the derivative of that rating matches a central
                        difference through a break in the section.
   - sfr_cross_section: a stream whose reaches carry a cross section, whose
@@ -64,9 +66,28 @@ CROSS_SECTION = [
     (1.0, 1.2, 1.0),
 ]
 
+# the same channel closed by a vertical wall standing on the bank, which is the
+# geometry a wetted vertical face is formed for; the wall stands low enough that
+# the water reaches it
+WALLED_SECTION = [
+    (0.0, 0.5, 1.0),
+    (0.0, 0.03, 1.0),
+    (0.3, 0.0, 1.0),
+    (0.7, 0.0, 1.0),
+    (1.0, 0.03, 1.0),
+    (1.0, 0.5, 1.0),
+]
+
 
 def _build_model(
-    ws, well_rate, inflow=5000.0, rhk=5.0, rgrd=1.0e-3, man=0.03, cross_section=False
+    ws,
+    well_rate,
+    inflow=5000.0,
+    rhk=5.0,
+    rgrd=1.0e-3,
+    man=0.03,
+    cross_section=False,
+    section=None,
 ):
     """Build a single-layer model with a chain of reaches across it."""
     ws = pl.Path(ws)
@@ -137,9 +158,9 @@ def _build_model(
             name = f"xs{n}"
             flopy.mf6.ModflowUtlsfrtab(
                 gwf,
-                nrow=len(CROSS_SECTION),
+                nrow=len(section or CROSS_SECTION),
                 ncol=3,
-                table=CROSS_SECTION,
+                table=section or CROSS_SECTION,
                 filename=f"{name}.txt",
                 pname=name,
             )
@@ -682,9 +703,10 @@ def _section_terms(ws):
     return terms
 
 
-def test_xs_rating(tmp_path):
+@pytest.mark.parametrize("section", [None, WALLED_SECTION])
+def test_xs_rating(tmp_path, section):
     """The rating reproduces the discharge the reach depth was solved against."""
-    ws = _build_model(tmp_path / "xs", WELL_RATE, cross_section=True)
+    ws = _build_model(tmp_path / "xs", WELL_RATE, cross_section=True, section=section)
     terms = _section_terms(ws)
     for n in range(1, NCOL):
         # the first reach is left out because its inflow is specified rather

--- a/autotest/test_sfr.py
+++ b/autotest/test_sfr.py
@@ -19,6 +19,12 @@ Cases:
                        together.
   - branching        : a stream that splits sends its flow on in the shares the
                        reaches below it are given.
+  - xs_rating        : the cross-section rating reproduces the discharge the
+                       forward model solved the reach depth against.
+  - xs_derivative    : the derivative of that rating matches a central
+                       difference through a break in the section.
+  - sfr_cross_section: a stream whose reaches carry a cross section, whose
+                       conductance follows the depth as well as the stage.
 """
 
 import glob
@@ -28,6 +34,7 @@ import sys
 
 import flopy
 import h5py
+import modflowapi
 import numpy as np
 import pytest
 
@@ -36,6 +43,8 @@ try:
 except ImportError:
     sys.path.insert(0, str(pl.Path("../").resolve()))
     import mf6adj
+
+from mf6adj.advanced_packages.sfr_cross_section import mannings_section
 
 mf6_bin, lib_name = mf6adj.get_conda_mf6_paths()
 
@@ -46,7 +55,19 @@ WELL_RATE = -2000.0
 STRTOP = 6.0
 
 
-def _build_model(ws, well_rate, inflow=5000.0, rhk=5.0, rgrd=1.0e-3, man=0.03):
+# a trapezoidal section, given as a fraction of the reach width and a height
+# over the streambed, with a roughness of the reach roughness throughout
+CROSS_SECTION = [
+    (0.0, 1.2, 1.0),
+    (0.2, 0.0, 1.0),
+    (0.8, 0.0, 1.0),
+    (1.0, 1.2, 1.0),
+]
+
+
+def _build_model(
+    ws, well_rate, inflow=5000.0, rhk=5.0, rgrd=1.0e-3, man=0.03, cross_section=False
+):
     """Build a single-layer model with a chain of reaches across it."""
     ws = pl.Path(ws)
     if ws.exists():
@@ -109,11 +130,26 @@ def _build_model(ws, well_rate, inflow=5000.0, rhk=5.0, rgrd=1.0e-3, man=0.03):
             # a downstream connection is given as a negative reach number
             conn.append(-(n + 1))
         connectiondata.append(conn)
+    crosssections = None
+    if cross_section:
+        crosssections = []
+        for n in range(NCOL):
+            name = f"xs{n}"
+            flopy.mf6.ModflowUtlsfrtab(
+                gwf,
+                nrow=len(CROSS_SECTION),
+                ncol=3,
+                table=CROSS_SECTION,
+                filename=f"{name}.txt",
+                pname=name,
+            )
+            crosssections.append([n, f"{name}.txt"])
     flopy.mf6.ModflowGwfsfr(
         gwf,
         nreaches=NCOL,
         packagedata=packagedata,
         connectiondata=connectiondata,
+        crosssections=crosssections,
         perioddata={0: [[0, "inflow", inflow]]},
         unit_conversion=128390.0,
         pname="sfr-1",
@@ -615,4 +651,87 @@ def test_sfr_branching(tmp_path):
         adjoint = float(hf["composite"]["wel6_q"][WELL_CELL])
     assert np.isclose(adjoint, finite_difference, rtol=2e-2), (
         f"adjoint {adjoint:.6e} against finite difference {finite_difference:.6e}"
+    )
+
+
+def _section_terms(ws):
+    """Return what the forward model holds for a reach with a cross section."""
+    mf6 = modflowapi.ModflowApi(str(lib_name), working_directory=str(ws))
+    mf6.initialize()
+    mf6.update()
+
+    def value(name):
+        return mf6.get_value(mf6.get_var_address(name, "SF", "SFR-1")).copy()
+
+    terms = {
+        name: value(name)
+        for name in (
+            "DEPTH",
+            "USFLOW",
+            "DSFLOW",
+            "STATION",
+            "XSHEIGHT",
+            "XSROUGH",
+            "ROUGH",
+            "SLOPE",
+        )
+    }
+    terms["IACROSS"] = value("IACROSS") - 1
+    terms["UNITCONV"] = float(value("UNITCONV")[0])
+    mf6.finalize()
+    return terms
+
+
+def test_xs_rating(tmp_path):
+    """The rating reproduces the discharge the reach depth was solved against."""
+    ws = _build_model(tmp_path / "xs", WELL_RATE, cross_section=True)
+    terms = _section_terms(ws)
+    for n in range(1, NCOL):
+        # the first reach is left out because its inflow is specified rather
+        # than routed, so the flow entering it is not reported
+        i0, i1 = int(terms["IACROSS"][n]), int(terms["IACROSS"][n + 1])
+        discharge, _ = mannings_section(
+            terms["STATION"][i0:i1],
+            terms["XSHEIGHT"][i0:i1],
+            terms["XSROUGH"][i0:i1],
+            terms["ROUGH"][n],
+            terms["UNITCONV"],
+            terms["SLOPE"][n],
+            terms["DEPTH"][n],
+        )
+        # MODFLOW sets the depth so the discharge is the mean of the flow in
+        # and the flow out
+        routed = 0.5 * (terms["USFLOW"][n] + terms["DSFLOW"][n])
+        assert abs(discharge - routed) < 1.0e-6 * abs(routed), (
+            f"reach {n} rating {discharge} against a routed flow of {routed}"
+        )
+
+
+@pytest.mark.parametrize("depth", [0.05, 0.3, 0.7, 0.999, 1.001, 1.5, 2.5])
+def test_xs_derivative(depth):
+    """The derivative of the rating matches a central difference."""
+    # a flat bed between sloping banks that end in a vertical wall at a height
+    # of one, so the section breaks at that depth
+    station = np.array([0.0, 0.0, 1.0, 4.0, 5.0, 5.0])
+    heights = np.array([3.0, 1.0, 0.0, 0.0, 1.0, 3.0])
+    roughfracs = np.array([1.0, 0.8, 1.0, 1.0, 1.2, 1.0])
+
+    def rating(d):
+        return mannings_section(station, heights, roughfracs, 0.03, 1.0, 1e-3, d)
+
+    _, derivative = rating(depth)
+    step = 1.0e-7
+    central = (rating(depth + step)[0] - rating(depth - step)[0]) / (2.0 * step)
+    assert abs(derivative - central) < 1.0e-6 * abs(central), (
+        f"depth {depth} derivative {derivative} against {central}"
+    )
+
+
+def test_sfr_cross_section(tmp_path):
+    """A reach with a cross section carries the rating and the conductance."""
+    adjoint, finite_difference = _compare(tmp_path, cross_section=True)
+    # the conductance follows the wetted perimeter, so both it and the rating
+    # move with the depth
+    assert abs(adjoint - finite_difference) < 1.0e-3 * abs(finite_difference), (
+        f"adjoint {adjoint} against a finite difference of {finite_difference}"
     )

--- a/mf6adj/advanced_packages/sfr.py
+++ b/mf6adj/advanced_packages/sfr.py
@@ -41,6 +41,32 @@ def _rating_discharge(width, depth, slope, rough, unitconv):
     return unitconv * width * depth**MANNING_EXPONENT * np.sqrt(slope) / rough
 
 
+def leakage_ratio(perimeter, dperimeter, cond, gwflow):
+    """Return the leakage derivative in depth as a multiple of the conductance.
+
+    The leakage is the conductance times the head difference across the
+    streambed, and the conductance is the wetted perimeter times a factor the
+    depth does not enter, so the leakage follows the depth as
+
+        dleak / ddepth = cond * (1 + (dP / dd) / P * (stage - head))
+
+    Only the bracket is returned, so the conductance the package reports sets
+    the magnitude and a reach on an inactive cell stays at zero. The head
+    difference is taken from the leakage, which MODFLOW reports positive where a
+    reach loses water, so a perched reach needs no separate treatment.
+    """
+    # both divisions are guarded against a zero denominator rather than against
+    # a negative one: a section whose wetted perimeter has gone negative still
+    # has a conductance, and both quotients carry their sign correctly
+    head_difference = np.divide(
+        gwflow, cond, out=np.zeros_like(cond), where=cond != 0.0
+    )
+    ratio = np.divide(
+        dperimeter, perimeter, out=np.zeros_like(perimeter), where=perimeter != 0.0
+    )
+    return 1.0 + ratio * head_difference
+
+
 def forward_terms(gwf, gwf_name: str, tag: str) -> dict:
     """Return the routing terms of a streamflow-routing package for one time step.
 
@@ -124,22 +150,8 @@ def forward_terms(gwf, gwf_name: str, tag: str) -> dict:
             )
             ddischarge[n] = MANNING_EXPONENT * discharge[n] / depth[n]
 
-    # The leakage is the conductance times the head difference across the
-    # streambed, and the conductance is the wetted perimeter times a factor the
-    # depth does not enter, so the leakage follows the depth as
-    #
-    #     dleak / ddepth = cond * (1 + (dP / P) * head difference)
-    #
-    # Only the bracket is formed here, so the conductance the package reports
-    # sets the magnitude and a reach on an inactive cell stays at zero. The head
-    # difference is taken from the leakage, which MODFLOW reports positive where
-    # a reach loses water, so a perched reach needs no separate treatment.
     cond = hk * length * perimeter / bthick
-    head_difference = np.divide(gwflow, cond, out=np.zeros(nreach), where=cond > 0.0)
-    ratio = np.divide(
-        dperimeter, perimeter, out=np.zeros(nreach), where=perimeter > 0.0
-    )
-    dleak_ratio = 1.0 + ratio * head_difference
+    dleak_ratio = leakage_ratio(perimeter, dperimeter, cond, gwflow)
 
     # A reach that gives up every drop it carries leaks its own inflow rather
     # than a head-dependent amount, which MODFLOW marks by leaving hcof at zero

--- a/mf6adj/advanced_packages/sfr.py
+++ b/mf6adj/advanced_packages/sfr.py
@@ -15,13 +15,16 @@ with no depth dependence, so the discharge is a power of the depth::
 
     qman(d) = unitconv * width * d ** (5 / 3) * sqrt(slope) / roughness
 
-and its derivative is that exponent times the discharge over the depth. Taking
-the discharge MODFLOW reports rather than rebuilding the rating keeps this
-correct whatever the unit conversion is.
+and its derivative is that exponent times the discharge over the depth. A reach
+with a cross section takes its discharge from the conveyance of the wetted
+section instead, and that rating and its derivative are formed in
+``sfr_cross_section``.
 """
 
 import numpy as np
 import scipy.sparse as sparse
+
+from .sfr_cross_section import mannings_section, wetted_perimeter
 
 # The Manning discharge of a reach without a cross section is this power of the
 # depth over the streambed, so its derivative is the exponent times the
@@ -54,8 +57,10 @@ def forward_terms(gwf, gwf_name: str, tag: str) -> dict:
     -------
     dict
         Depth, discharge, the derivative of discharge with respect to depth,
-        and the reach network. ``reach_is_free`` marks a reach whose depth is
-        solved, as opposed to one that is dry or holds a specified stage.
+        the derivative of the leakage with respect to depth as a multiple of
+        the conductance, and the reach network. ``reach_is_free`` marks a reach
+        whose depth is solved, as opposed to one that is dry or holds a
+        specified stage.
     """
 
     def value(name):
@@ -77,19 +82,64 @@ def forward_terms(gwf, gwf_name: str, tag: str) -> dict:
     rough = value("ROUGH")
     unitconv = float(value("UNITCONV")[0])
 
-    # a reach with a cross section follows a rating this does not reproduce
     ncrosspts = optional("NCROSSPTS", 1, nreach)
     has_section = (ncrosspts > 1).astype(int)
+    if has_section.max() > 0:
+        iacross = value("IACROSS") - 1
+        station = value("STATION")
+        xsheight = value("XSHEIGHT")
+        xsrough = value("XSROUGH")
+
+    # the leakage of a reach follows its depth through the stage, and, where a
+    # cross section sets the wetted perimeter, through the conductance as well
+    hk = value("HK")
+    length = value("LENGTH")
+    bthick = value("BTHICK")
+    gwflow = value("GWFLOW")
+    perimeter = width.copy()
+    dperimeter = np.zeros(nreach)
 
     discharge = np.zeros(nreach)
     ddischarge = np.zeros(nreach)
     for n in range(nreach):
-        if depth[n] <= MIN_DEPTH or has_section[n]:
+        if depth[n] <= MIN_DEPTH:
             continue
-        discharge[n] = _rating_discharge(
-            width[n], depth[n], slope[n], rough[n], unitconv
-        )
-        ddischarge[n] = MANNING_EXPONENT * discharge[n] / depth[n]
+        if has_section[n]:
+            i0, i1 = int(iacross[n]), int(iacross[n + 1])
+            perimeter[n], dperimeter[n] = wetted_perimeter(
+                station[i0:i1], xsheight[i0:i1], depth[n]
+            )
+            discharge[n], ddischarge[n] = mannings_section(
+                station[i0:i1],
+                xsheight[i0:i1],
+                xsrough[i0:i1],
+                rough[n],
+                unitconv,
+                slope[n],
+                depth[n],
+            )
+        else:
+            discharge[n] = _rating_discharge(
+                width[n], depth[n], slope[n], rough[n], unitconv
+            )
+            ddischarge[n] = MANNING_EXPONENT * discharge[n] / depth[n]
+
+    # The leakage is the conductance times the head difference across the
+    # streambed, and the conductance is the wetted perimeter times a factor the
+    # depth does not enter, so the leakage follows the depth as
+    #
+    #     dleak / ddepth = cond * (1 + (dP / P) * head difference)
+    #
+    # Only the bracket is formed here, so the conductance the package reports
+    # sets the magnitude and a reach on an inactive cell stays at zero. The head
+    # difference is taken from the leakage, which MODFLOW reports positive where
+    # a reach loses water, so a perched reach needs no separate treatment.
+    cond = hk * length * perimeter / bthick
+    head_difference = np.divide(gwflow, cond, out=np.zeros(nreach), where=cond > 0.0)
+    ratio = np.divide(
+        dperimeter, perimeter, out=np.zeros(nreach), where=perimeter > 0.0
+    )
+    dleak_ratio = 1.0 + ratio * head_difference
 
     # A reach that gives up every drop it carries leaks its own inflow rather
     # than a head-dependent amount, which MODFLOW marks by leaving hcof at zero
@@ -97,12 +147,9 @@ def forward_terms(gwf, gwf_name: str, tag: str) -> dict:
     # it rather than its own stage, and that coupling is not formed here.
     flow_limited = ((hcof == 0.0) & (depth > MIN_DEPTH) & (dsflow <= 0.0)).astype(int)
 
-    # a reach that carries no water, whose stage follows a cross section, or
-    # whose leakage is limited by the flow it carries, has no depth for the
-    # adjoint to solve for
-    is_free = ((depth > MIN_DEPTH) & (has_section == 0) & (flow_limited == 0)).astype(
-        int
-    )
+    # a reach that carries no water, or whose leakage is limited by the flow it
+    # carries, has no depth for the adjoint to solve for
+    is_free = ((depth > MIN_DEPTH) & (flow_limited == 0)).astype(int)
 
     # the reach network: idir is positive for a connection to an upstream reach
     ia = value("IA") - 1
@@ -129,6 +176,7 @@ def forward_terms(gwf, gwf_name: str, tag: str) -> dict:
     return {
         "reach_ddischarge": ddischarge,
         "reach_depth": depth,
+        "reach_dleak_ratio": dleak_ratio,
         "reach_discharge": discharge,
         "reach_fraction": fraction,
         "reach_has_section": has_section,
@@ -175,14 +223,6 @@ class SfrCoupling:
             return
         self._warned.add(pname)
 
-        if grp["reach_has_section"][:].max() > 0:
-            self._warn(
-                f"streamflow-routing package '{pname}' has reaches with a cross "
-                "section. Their discharge follows the section rather than a "
-                "power of the depth, and that derivative is not formed, so "
-                "those reaches keep a fixed stage and the sensitivity is "
-                "approximate."
-            )
         if grp["reach_flow_limited"][:].max() > 0:
             self._warn(
                 f"streamflow-routing package '{pname}' has reaches that give up "
@@ -203,8 +243,8 @@ class SfrCoupling:
         Returns
         -------
         list
-            One entry per streamflow-routing package. A reach that is dry, or
-            that follows a cross section, is left out.
+            One entry per streamflow-routing package. A reach that is dry is
+            left out.
         """
         found = []
         for ptype, pnames in gwf_package_dict.items():
@@ -229,6 +269,7 @@ class SfrCoupling:
                         "cond": grp["bound"][:, 1],
                         "hcof": grp["hcof"][:],
                         "ddischarge": grp["reach_ddischarge"][:],
+                        "dleak": grp["bound"][:, 1] * grp["reach_dleak_ratio"][:],
                         "flow_limited": grp["reach_flow_limited"][:] == 1,
                         "fraction": grp["reach_fraction"][:],
                         "free": free,
@@ -270,7 +311,7 @@ class SfrCoupling:
                     continue
                 key = (block["name"], ireach)
                 result[key] = result.get(key, 0.0) + weights[node] * float(
-                    block["cond"][ireach]
+                    block["dleak"][ireach]
                 )
         return result
 
@@ -292,7 +333,7 @@ class SfrCoupling:
         The flow leaving a reach is its Manning discharge less half of its
         leakage, so it follows the reach depth and the head beneath it.
         """
-        ddepth = float(block["ddischarge"][iup]) - 0.5 * float(block["cond"][iup])
+        ddepth = float(block["ddischarge"][iup]) - 0.5 * float(block["dleak"][iup])
         dhead = 0.5 * float(block["cond"][iup])
         return ddepth, dhead
 
@@ -370,14 +411,14 @@ class SfrCoupling:
                     continue
                 icol = self.columns[key]
                 node = int(block["node"][n])
-                cond = float(block["cond"][n])
+                dleak = float(block["dleak"][n])
 
                 # the aquifer sees the reach through its stage
-                drds[node, icol] += cond
+                drds[node, icol] += dleak
 
                 # the reach equation: the Manning discharge against the mean of
                 # the flow in and out, so half of the leakage appears here
-                drdr[icol, icol] += float(block["ddischarge"][n]) + 0.5 * cond
+                drdr[icol, icol] += float(block["ddischarge"][n]) + 0.5 * dleak
                 drdh[icol, node] += 0.5 * float(block["hcof"][n])
 
                 # what this reach receives from the reaches above it
@@ -391,7 +432,7 @@ class SfrCoupling:
                     jcol = self.columns[upstream]
                     iup = int(ja[icon])
                     drdr[icol, jcol] -= share * float(block["ddischarge"][iup])
-                    drdr[icol, jcol] += 0.5 * share * float(block["cond"][iup])
+                    drdr[icol, jcol] += 0.5 * share * float(block["dleak"][iup])
                     # the flow leaving the upstream reach carries half of its
                     # leakage, so the head there enters with the same sign as
                     # this reach's own

--- a/mf6adj/advanced_packages/sfr_cross_section.py
+++ b/mf6adj/advanced_packages/sfr_cross_section.py
@@ -56,7 +56,15 @@ def _vertical_faces(stations, heights):
 
 
 def _wet_vertical_face(heights, n, d, left):
-    """Return the wetted length of a vertical face, and how it follows depth."""
+    """Return the wetted length of a vertical face, and how it follows depth.
+
+    A water surface below the foot of the face gives a negative length, which
+    MODFLOW 6 neither guards against nor discards. That is reproduced rather
+    than corrected: the sensitivity has to be taken of the rating the forward
+    model actually used, and clamping here would differentiate a different one.
+    A segment left with a negative perimeter carries no conveyance, in this
+    routine as in MODFLOW.
+    """
     if left:
         above, below = heights[n - 1], heights[n]
     else:

--- a/mf6adj/advanced_packages/sfr_cross_section.py
+++ b/mf6adj/advanced_packages/sfr_cross_section.py
@@ -1,0 +1,170 @@
+"""Cross-section rating for a streamflow-routing reach.
+
+A reach given more than one station-height point takes its discharge from the
+conveyance of the wetted section rather than from a power of the depth, so the
+5/3 rating of a rectangular reach does not hold. The section is a chain of
+straight segments between the points, and MODFLOW 6 sums the conveyance of the
+wetted part of each::
+
+    K = sum_n a_n ** (5 / 3) * p_n ** (-2 / 3) / r_n
+    qman = unitconv * K * sqrt(slope)
+
+where a_n and p_n are the wetted area and wetted perimeter of segment n and
+r_n is the reach roughness times the roughness fraction of the segment. Both
+a_n and p_n follow the depth, and the derivative of the rating is taken from
+them rather than from a perturbation of the discharge.
+
+The wetted perimeter of the section also sets the streambed conductance, so
+unlike a rectangular reach, whose conductance is its width at any depth, the
+leakage of a reach with a cross section follows the depth through the
+conductance as well as through the stage.
+"""
+
+import numpy as np
+
+
+def _wetted_station(x0, x1, d0, d1, d):
+    """Return the wetted extent of one segment and the heights bounding it."""
+    dmin = min(d0, d1)
+    dmax = max(d0, d1)
+    if d <= dmin:
+        x1 = x0
+    elif d < dmax:
+        station = x0 + (x1 - x0) * (d - d0) / (d1 - d0)
+        if d0 > d1:
+            x0 = station
+        else:
+            x1 = station
+    return x0, x1, dmin, dmax
+
+
+def _vertical_faces(stations, heights):
+    """Return whether each segment has a vertical face on its left and right."""
+    npts = stations.shape[0]
+    left = np.zeros(npts - 1, dtype=bool)
+    right = np.zeros(npts - 1, dtype=bool)
+    for n in range(npts - 1):
+        if n > 0 and stations[n - 1] == stations[n] and heights[n - 1] > heights[n]:
+            left[n] = True
+        if (
+            n < npts - 2
+            and stations[n + 2] == stations[n + 1]
+            and heights[n + 2] > heights[n + 1]
+        ):
+            right[n] = True
+    return left, right
+
+
+def _wet_vertical_face(heights, n, d, left):
+    """Return the wetted length of a vertical face, and how it follows depth."""
+    if left:
+        above, below = heights[n - 1], heights[n]
+    else:
+        above, below = heights[n + 2], heights[n + 1]
+    if above > d:
+        # the face is wetted only to the depth, so it grows with it
+        return d - below, 1.0
+    return above - below, 0.0
+
+
+def _segment_geometry(stations, heights, d):
+    """Return the wetted area and perimeter of each segment, and their slopes."""
+    npts = stations.shape[0]
+    area = np.zeros(npts - 1)
+    darea = np.zeros(npts - 1)
+    perimeter = np.zeros(npts - 1)
+    dperimeter = np.zeros(npts - 1)
+    left, right = _vertical_faces(stations, heights)
+
+    for n in range(npts - 1):
+        x0, x1, dmin, dmax = _wetted_station(
+            stations[n], stations[n + 1], heights[n], heights[n + 1], d
+        )
+        xlen = x1 - x0
+        if xlen > 0.0:
+            # the top width of the wetted segment is how its area grows
+            if d > dmax:
+                area[n] = xlen * (d - dmax)
+            if dmax != dmin and d > dmin:
+                if d < dmax:
+                    area[n] += 0.5 * (d - dmin) * xlen
+                else:
+                    area[n] += 0.5 * (dmax - dmin) * xlen
+            darea[n] = xlen
+            dlen = dmax - dmin if d > dmax else d - dmin
+        else:
+            dlen = min(d, dmax) - dmin if d > dmin else 0.0
+
+        perimeter[n] = np.sqrt(xlen**2 + dlen**2)
+        if perimeter[n] > 0.0 and dmin < d < dmax:
+            # the wetted length grows with the depth along both directions
+            slope = (stations[n + 1] - stations[n]) / (dmax - dmin)
+            dperimeter[n] = np.sqrt(slope**2 + 1.0) if xlen > 0.0 else 1.0
+
+        if n > 0 and left[n]:
+            face, dface = _wet_vertical_face(heights, n, d, True)
+            perimeter[n] += face
+            dperimeter[n] += dface
+        if n < npts - 2 and right[n]:
+            face, dface = _wet_vertical_face(heights, n, d, False)
+            perimeter[n] += face
+            dperimeter[n] += dface
+
+    return area, darea, perimeter, dperimeter
+
+
+def wetted_perimeter(stations, heights, d):
+    """Return the wetted perimeter of a cross section and its slope in the depth.
+
+    The streambed conductance of a reach follows its wetted perimeter, so for a
+    reach with a cross section the conductance follows the depth as well.
+    """
+    _, _, perimeter, dperimeter = _segment_geometry(stations, heights, d)
+    return float(perimeter.sum()), float(dperimeter.sum())
+
+
+def mannings_section(stations, heights, roughfracs, roughness, unitconv, slope, d):
+    """Return the discharge of a cross section and its derivative in the depth.
+
+    Parameters
+    ----------
+    stations : numpy.ndarray
+        Station of each cross-section point, already scaled by the reach width.
+    heights : numpy.ndarray
+        Height of each cross-section point above the streambed.
+    roughfracs : numpy.ndarray
+        Roughness of each point as a fraction of the reach roughness.
+    roughness : float
+        Reach roughness.
+    unitconv : float
+        Unit conversion of the package.
+    slope : float
+        Reach slope.
+    d : float
+        Depth over the lowest point of the section.
+
+    Returns
+    -------
+    tuple
+        The discharge and its derivative with respect to the depth.
+    """
+    area, darea, perimeter, dperimeter = _segment_geometry(stations, heights, d)
+    if perimeter.sum() <= 0.0:
+        return 0.0, 0.0
+
+    conveyance = 0.0
+    dconveyance = 0.0
+    for n in range(perimeter.shape[0]):
+        rough = roughness * roughfracs[n]
+        if perimeter[n] * rough <= 0.0:
+            continue
+        a, p = area[n], perimeter[n]
+        conveyance += a ** (5.0 / 3.0) * p ** (-2.0 / 3.0) / rough
+        if a > 0.0:
+            dconveyance += (
+                (5.0 / 3.0) * a ** (2.0 / 3.0) * darea[n] * p ** (-2.0 / 3.0)
+                - (2.0 / 3.0) * a ** (5.0 / 3.0) * p ** (-5.0 / 3.0) * dperimeter[n]
+            ) / rough
+
+    factor = unitconv * np.sqrt(slope)
+    return factor * conveyance, factor * dconveyance


### PR DESCRIPTION
A reach with more than one station-height point took its discharge from a section rating rather than a power of the depth, so it was left with a fixed depth and a warning. The rating is now reproduced and differentiated from the wetted area and perimeter of each segment, and the streambed conductance, which follows the wetted perimeter, carries its own term in the depth.

The rating reproduces the discharge the forward model solved each depth against to eleven significant figures, and its derivative matches a central difference to nine. On a chain of reaches carrying a trapezoidal section, holding the depths fixed gave a capture sensitivity in error by 1.7 percent; carrying both derivatives reduced it to 0.002 percent.

Addresses the cross-section half of #82.