### PR TITLE
feat(sfr): differentiate the flow a diversion takes

### DIFF
--- a/autotest/test_sfr.py
+++ b/autotest/test_sfr.py
@@ -33,6 +33,8 @@ Cases:
                        the flows, in both regimes of the piecewise ones.
   - diversion_unknown: flows that leave two rules diverting the same amount
                        are reported as undetermined rather than guessed at.
+  - diversion_warned : an undetermined rule is reported on whichever time step
+                       it arises, and named, and reported only once.
   - sfr_diversion    : a stream carrying a diversion under each of the four
                        rules.
 """
@@ -54,6 +56,7 @@ except ImportError:
     sys.path.insert(0, str(pl.Path("../").resolve()))
     import mf6adj
 
+import mf6adj.advanced_packages.sfr
 from mf6adj.advanced_packages.sfr import leakage_ratio
 from mf6adj.advanced_packages.sfr_cross_section import (
     mannings_section,
@@ -904,3 +907,37 @@ def test_sfr_diversion(tmp_path, rule, rate):
     assert abs(adjoint - finite_difference) < 5.0e-5 * abs(finite_difference), (
         f"{rule} adjoint {adjoint} against a finite difference of {finite_difference}"
     )
+
+
+def test_diversion_warned():
+    """An undetermined rule is reported on the step it arises, and named once."""
+
+    class Recorder:
+        def __init__(self):
+            self.messages = []
+
+        def warning(self, message):
+            self.messages.append(message)
+
+    log = Recorder()
+    coupling = mf6adj.advanced_packages.sfr.SfrCoupling(logger=log)
+    clean = {
+        "reach_flow_limited": np.zeros(9, dtype=int),
+        "reach_undetermined_diversion": np.zeros(9, dtype=int),
+    }
+    tied = dict(clean)
+    tied["reach_undetermined_diversion"] = np.array(
+        [0, 0, 0, 1, 0, 0, 0, 0, 0], dtype=int
+    )
+
+    # the sweep meets a step with nothing to report before the one that has it
+    coupling._warn_once("sfr-1", clean)
+    assert not log.messages
+
+    coupling._warn_once("sfr-1", tied)
+    assert len(log.messages) == 1
+    assert "reach 4" in log.messages[0]
+
+    # and the same condition is not reported again on later steps
+    coupling._warn_once("sfr-1", tied)
+    assert len(log.messages) == 1

--- a/autotest/test_sfr.py
+++ b/autotest/test_sfr.py
@@ -29,6 +29,12 @@ Cases:
                        MODFLOW lets it, still carries a leakage derivative.
   - sfr_cross_section: a stream whose reaches carry a cross section, whose
                        conductance follows the depth as well as the stage.
+  - diversion_rule   : the derivative of each diversion rule is recovered from
+                       the flows, in both regimes of the piecewise ones.
+  - diversion_unknown: flows that do not determine the rule are reported as
+                       undetermined rather than guessed at.
+  - sfr_diversion    : a stream carrying a diversion under each of the four
+                       rules.
 """
 
 import glob
@@ -53,6 +59,7 @@ from mf6adj.advanced_packages.sfr_cross_section import (
     mannings_section,
     wetted_perimeter,
 )
+from mf6adj.advanced_packages.sfr_diversion import diversion_derivative
 
 mf6_bin, lib_name = mf6adj.get_conda_mf6_paths()
 
@@ -85,6 +92,11 @@ WALLED_SECTION = [
 ]
 
 
+# the reach the diversion is taken from, and the row the diverted reach sits in
+DIVERT_FROM = 3
+DIVERT_ROW = REACH_ROW + 2
+
+
 def _build_model(
     ws,
     well_rate,
@@ -94,6 +106,7 @@ def _build_model(
     man=0.03,
     cross_section=False,
     section=None,
+    diversion=None,
 ):
     """Build a single-layer model with a chain of reaches across it."""
     ws = pl.Path(ws)
@@ -134,6 +147,10 @@ def _build_model(
     packagedata, connectiondata = [], []
     for n in range(NCOL):
         nconn = 1 if n in (0, NCOL - 1) else 2
+        ndv = 0
+        if diversion is not None and n == DIVERT_FROM:
+            nconn += 1
+            ndv = 1
         packagedata.append(
             [
                 n,
@@ -147,7 +164,7 @@ def _build_model(
                 man,
                 nconn,
                 1.0,
-                0,
+                ndv,
             ]
         )
         conn = [n]
@@ -156,7 +173,33 @@ def _build_model(
         if n < NCOL - 1:
             # a downstream connection is given as a negative reach number
             conn.append(-(n + 1))
+        if ndv:
+            conn.append(-NCOL)
         connectiondata.append(conn)
+
+    diversions = None
+    if diversion is not None:
+        rule = diversion[0]
+        packagedata.append(
+            [
+                NCOL,
+                (0, DIVERT_ROW, DIVERT_FROM),
+                DELRC,
+                5.0,
+                rgrd,
+                STRTOP - 0.01 * DIVERT_FROM,
+                1.0,
+                rhk,
+                man,
+                1,
+                # a diverted reach takes what the diversion gives it rather
+                # than a share, so MODFLOW requires an upstream fraction of zero
+                0.0,
+                0,
+            ]
+        )
+        connectiondata.append([NCOL, DIVERT_FROM])
+        diversions = [[DIVERT_FROM, 0, NCOL, rule]]
     crosssections = None
     if cross_section:
         crosssections = []
@@ -171,13 +214,17 @@ def _build_model(
                 pname=name,
             )
             crosssections.append([n, f"{name}.txt"])
+    perioddata = [[0, "inflow", inflow]]
+    if diversion is not None:
+        perioddata.append([DIVERT_FROM, "diversion", 0, diversion[1]])
     flopy.mf6.ModflowGwfsfr(
         gwf,
-        nreaches=NCOL,
+        nreaches=NCOL + (0 if diversion is None else 1),
         packagedata=packagedata,
         connectiondata=connectiondata,
         crosssections=crosssections,
-        perioddata={0: [[0, "inflow", inflow]]},
+        diversions=diversions,
+        perioddata={0: perioddata},
         unit_conversion=128390.0,
         pname="sfr-1",
     )
@@ -188,13 +235,18 @@ def _build_model(
     return ws
 
 
-def _write_adj(ws):
+def _write_adj(ws, diversion=None):
     """Measure the exchange between every reach and the aquifer."""
     path = pl.Path(ws) / "test.adj"
     with open(path, "w") as f:
         f.write("begin performance_measure pm\n")
         for n in range(NCOL):
             f.write(f"1 1 1 {REACH_ROW + 1} {n + 1} sfr-1 direct 1.0 -1.0e+30\n")
+        if diversion is not None:
+            # the diverted reach carries exchange of its own
+            f.write(
+                f"1 1 1 {DIVERT_ROW + 1} {DIVERT_FROM + 1} sfr-1 direct 1.0 -1.0e+30\n"
+            )
         f.write("end performance_measure\n")
     return path
 
@@ -221,10 +273,10 @@ def _compare(tmpdir, **kwargs):
     """Return the adjoint sensitivity and its finite-difference counterpart."""
     dq = -50.0
     base = _build_model(tmpdir / "base", WELL_RATE, **kwargs)
-    _write_adj(base)
+    _write_adj(base, diversion=kwargs.get("diversion"))
     _solve(base)
     pert = _build_model(tmpdir / "pert", WELL_RATE + dq, **kwargs)
-    _write_adj(pert)
+    _write_adj(pert, diversion=kwargs.get("diversion"))
     _solve(pert)
 
     finite_difference = (_measure_value(pert) - _measure_value(base)) / dq
@@ -794,3 +846,52 @@ def test_xs_negative_perimeter():
     assert ratio[0] == pytest.approx(expected)
     # the conductance alone would be the answer only if the section were flat
     assert ratio[0] != pytest.approx(1.0)
+
+
+@pytest.mark.parametrize(
+    "available, requested, taken, expected",
+    [
+        # FRACTION takes a share of whatever it is given
+        (4000.0, 0.25, 1000.0, 0.25),
+        # EXCESS passes the first `requested` on and takes the rest
+        (4000.0, 3000.0, 1000.0, 1.0),
+        (2000.0, 3000.0, 0.0, 0.0),
+        # UPTO takes what it asks for until there is less than that
+        (4000.0, 500.0, 500.0, 0.0),
+        (300.0, 500.0, 300.0, 1.0),
+        # THRESHOLD takes all or nothing, and moves with neither
+        (4000.0, 1000.0, 1000.0, 0.0),
+        (800.0, 1000.0, 0.0, 0.0),
+    ],
+)
+def test_diversion_rule(available, requested, taken, expected):
+    """The flows determine how a diverted flow follows the flow available."""
+    derivative, determined = diversion_derivative(available, requested, taken)
+    assert determined
+    assert derivative == pytest.approx(expected)
+
+
+def test_diversion_unknown():
+    """Flows that leave the rule open are reported rather than guessed at."""
+    # a reach with nothing to give diverts nothing under every rule, and the
+    # rules do not agree on how that would change
+    derivative, determined = diversion_derivative(0.0, 0.5, 0.0)
+    assert not determined
+    assert derivative == 0.0
+
+
+@pytest.mark.parametrize(
+    "rule, rate",
+    [
+        ("FRACTION", 0.25),
+        ("UPTO", 9000.0),
+        ("EXCESS", 3000.0),
+        ("THRESHOLD", 1000.0),
+    ],
+)
+def test_sfr_diversion(tmp_path, rule, rate):
+    """A diversion scales the flow the reaches below it are routed."""
+    adjoint, finite_difference = _compare(tmp_path, diversion=(rule, rate))
+    assert abs(adjoint - finite_difference) < 5.0e-5 * abs(finite_difference), (
+        f"{rule} adjoint {adjoint} against a finite difference of {finite_difference}"
+    )

--- a/autotest/test_sfr.py
+++ b/autotest/test_sfr.py
@@ -31,8 +31,8 @@ Cases:
                        conductance follows the depth as well as the stage.
   - diversion_rule   : the derivative of each diversion rule is recovered from
                        the flows, in both regimes of the piecewise ones.
-  - diversion_unknown: flows that do not determine the rule are reported as
-                       undetermined rather than guessed at.
+  - diversion_unknown: flows that leave two rules diverting the same amount
+                       are reported as undetermined rather than guessed at.
   - sfr_diversion    : a stream carrying a diversion under each of the four
                        rules.
 """
@@ -871,11 +871,20 @@ def test_diversion_rule(available, requested, taken, expected):
     assert derivative == pytest.approx(expected)
 
 
-def test_diversion_unknown():
+@pytest.mark.parametrize(
+    "available, requested, taken",
+    [
+        # EXCESS passes on the rate and takes the rest, so where the flow is
+        # exactly twice the rate it takes the rate itself, as UPTO and
+        # THRESHOLD do, and the three do not agree on how that would change
+        (2000.0, 1000.0, 1000.0),
+        # FRACTION takes the rate itself where the flow available is one
+        (1.0, 0.4, 0.4),
+    ],
+)
+def test_diversion_unknown(available, requested, taken):
     """Flows that leave the rule open are reported rather than guessed at."""
-    # a reach with nothing to give diverts nothing under every rule, and the
-    # rules do not agree on how that would change
-    derivative, determined = diversion_derivative(0.0, 0.5, 0.0)
+    derivative, determined = diversion_derivative(available, requested, taken)
     assert not determined
     assert derivative == 0.0
 

--- a/mf6adj/advanced_packages/sfr.py
+++ b/mf6adj/advanced_packages/sfr.py
@@ -274,23 +274,40 @@ class SfrCoupling:
             self.logger.warning(message)
 
     def _warn_once(self, pname: str, grp) -> None:
-        """Warn where a reach's routing is differentiated only in part."""
-        if pname in self._warned:
-            return
-        self._warned.add(pname)
+        """Warn where a reach's routing is differentiated only in part.
 
-        if grp["reach_flow_limited"][:].max() > 0:
+        Each condition is reported the first time step it is met on, rather
+        than only where it is met on the first step of the sweep.
+        """
+        conditions = (
+            (
+                "reach_flow_limited",
+                "{reaches} give up all of the water they carry. Their leakage "
+                "follows the reaches above them rather than their own stage, "
+                "and that coupling is not formed",
+            ),
+            (
+                "reach_undetermined_diversion",
+                "the flows at {reaches} leave the rule of a diversion open, "
+                "because two rules divert the same amount there and respond "
+                "differently. The flow the diversion takes is held fixed",
+            ),
+        )
+        for flag, message in conditions:
+            if (pname, flag) in self._warned or flag not in grp:
+                continue
+            marked = np.flatnonzero(np.asarray(grp[flag][:]) > 0)
+            if marked.size == 0:
+                continue
+            self._warned.add((pname, flag))
+            listed = ", ".join(str(int(n) + 1) for n in marked[:5])
+            if marked.size > 5:
+                listed += f", and {marked.size - 5} more"
+            reaches = f"reach {listed}" if marked.size == 1 else f"reaches {listed}"
             self._warn(
-                f"streamflow-routing package '{pname}' has reaches that give up "
-                "all of the water they carry. Their leakage follows the reaches "
-                "above them rather than their own stage, and that coupling is "
-                "not formed, so the sensitivity is approximate."
-            )
-        if grp["reach_undetermined_diversion"][:].max() > 0:
-            self._warn(
-                f"streamflow-routing package '{pname}' has diversions whose rule "
-                "the flows do not determine. The flow they take is held fixed, "
-                "so the sensitivity is approximate."
+                f"streamflow-routing package '{pname}': "
+                + message.format(reaches=reaches)
+                + ", so the sensitivity is approximate."
             )
 
     def blocks(self, sol_dataset, gwf_package_dict) -> list:

--- a/mf6adj/advanced_packages/sfr.py
+++ b/mf6adj/advanced_packages/sfr.py
@@ -25,6 +25,7 @@ import numpy as np
 import scipy.sparse as sparse
 
 from .sfr_cross_section import mannings_section, wetted_perimeter
+from .sfr_diversion import reach_coefficients
 
 # The Manning discharge of a reach without a cross section is this power of the
 # depth over the streambed, so its derivative is the exponent times the
@@ -169,21 +170,63 @@ def forward_terms(gwf, gwf_name: str, tag: str) -> dict:
     idir = value("IDIR")
     ustrf = value("USTRF")
 
-    # the share of an upstream reach's outflow this reach receives
-    total = np.zeros(nreach)
+    # MODFLOW keeps the total of the shares its downstream reaches are given,
+    # which leaves out both a diversion and an inactive reach, so it is read
+    # rather than summed here
+    ftotnd = value("FTOTND")
+
+    ndiv = optional("NDIV", 0, nreach)
+    idiv = optional("IDIV", 0, ja.shape[0])
+    if ndiv.max() > 0:
+        iadiv = value("IADIV") - 1
+        divflow = value("DIVFLOW")
+        divq = value("DIVQ")
+
+    # what each diversion takes out of the flow a reach passes on, and what is
+    # left for the reaches below it
+    div_coefficient = np.zeros(ja.shape[0])
+    outflow_factor = np.ones(nreach)
+    undetermined = np.zeros(nreach, dtype=int)
     for n in range(nreach):
-        for icon in range(ia[n], ia[n + 1]):
-            if idir[icon] > 0:
-                # ja[icon] is upstream of n, so n is one of its outflows
-                total[ja[icon]] += ustrf[n]
+        taken_at = [
+            icon
+            for icon in range(ia[n], ia[n + 1])
+            if idir[icon] <= 0 and idiv[icon] > 0
+        ]
+        if not taken_at or dsflow[n] <= 0.0:
+            continue
+        # the diversions are applied in the order of the connections, each
+        # taking from what the one before it left
+        positions = [int(iadiv[n] + idiv[icon] - 1) for icon in taken_at]
+        coefficients, remaining, determined = reach_coefficients(
+            float(dsflow[n]),
+            [float(divflow[j]) for j in positions],
+            [float(divq[j]) for j in positions],
+        )
+        for icon, coefficient in zip(taken_at, coefficients):
+            div_coefficient[icon] = coefficient
+        outflow_factor[n] = remaining
+        undetermined[n] = 0 if determined else 1
+
+    # The share of an upstream reach's outflow this reach receives. MODFLOW
+    # pairs the two by looking down the upstream reach's own connections, and
+    # the same pairing is made here so that a diversion is met on the
+    # connection it is taken on.
     fraction = np.zeros(ja.shape[0])
     for n in range(nreach):
         for icon in range(ia[n], ia[n + 1]):
-            if idir[icon] > 0:
-                share = total[ja[icon]]
-                fraction[icon] = ustrf[n] / share if share > 0.0 else 0.0
-
-    ndiv = optional("NDIV", 0, nreach)
+            if idir[icon] <= 0:
+                continue
+            iup = int(ja[icon])
+            for jcon in range(ia[iup], ia[iup + 1]):
+                if idir[jcon] > 0 or int(ja[jcon]) != n:
+                    continue
+                if idiv[jcon] > 0:
+                    # this reach is fed by a diversion rather than by a share
+                    fraction[icon] = div_coefficient[jcon]
+                elif ftotnd[iup] > 0.0:
+                    fraction[icon] = ustrf[n] / ftotnd[iup] * outflow_factor[iup]
+                break
 
     return {
         "reach_ddischarge": ddischarge,
@@ -198,6 +241,7 @@ def forward_terms(gwf, gwf_name: str, tag: str) -> dict:
         "reach_is_free": is_free,
         "reach_ja": ja,
         "reach_ndiv": ndiv,
+        "reach_undetermined_diversion": undetermined,
     }
 
 
@@ -242,11 +286,11 @@ class SfrCoupling:
                 "above them rather than their own stage, and that coupling is "
                 "not formed, so the sensitivity is approximate."
             )
-        if grp["reach_ndiv"][:].max() > 0:
+        if grp["reach_undetermined_diversion"][:].max() > 0:
             self._warn(
-                f"streamflow-routing package '{pname}' has diversions. The flow "
-                "they take is not differentiated, so the sensitivity is "
-                "approximate."
+                f"streamflow-routing package '{pname}' has diversions whose rule "
+                "the flows do not determine. The flow they take is held fixed, "
+                "so the sensitivity is approximate."
             )
 
     def blocks(self, sol_dataset, gwf_package_dict) -> list:

--- a/mf6adj/advanced_packages/sfr_diversion.py
+++ b/mf6adj/advanced_packages/sfr_diversion.py
@@ -1,0 +1,94 @@
+"""Diversions taken from a streamflow-routing reach.
+
+A diversion removes water from the flow a reach passes on, under one of four
+rules. Writing $v$ for the rate the diversion is given and $q$ for the flow
+available to it when its turn comes, the rules and the derivatives that matter
+to the adjoint are
+
+===========  =====================  ==============
+rule         diverted               d(diverted)/dq
+===========  =====================  ==============
+FRACTION     ``q * v``              ``v``
+EXCESS       ``max(q - v, 0)``      1 above ``v``
+UPTO         ``min(v, q)``          1 below ``v``
+THRESHOLD    ``v`` if ``q >= v``    0
+===========  =====================  ==============
+
+MODFLOW 6 keeps the rule in a character array that is not in its memory store,
+so which one is in effect cannot be read. It does not have to be. The flow
+available to a diversion, the rate it was given, and the flow it actually took
+are all recoverable, and those three determine the derivative: where two rules
+give the same diverted flow they also give the same derivative, so the rule
+itself can stay unknown.
+"""
+
+import numpy as np
+
+# the flows are formed in one pass rather than iterated on, so a rule that is
+# in effect reproduces the diverted flow to rounding
+MATCH_TOL = 1.0e-9
+
+
+def _candidates(available, requested):
+    """Return what each rule would divert, and how that follows the flow."""
+    return (
+        (available * requested, requested),
+        (max(available - requested, 0.0), 1.0 if available > requested else 0.0),
+        (min(requested, available), 1.0 if available < requested else 0.0),
+        (requested if available >= requested else 0.0, 0.0),
+    )
+
+
+def diversion_derivative(available, requested, taken):
+    """Return how a diverted flow follows the flow available to the diversion.
+
+    Returns
+    -------
+    tuple
+        The derivative, and whether the flows determine it. Where no rule
+        reproduces the diverted flow, or the rules that do disagree, the
+        derivative is reported as undetermined and returned as zero.
+    """
+    scale = max(abs(available), abs(requested), abs(taken), 1.0)
+    slopes = [
+        slope
+        for diverted, slope in _candidates(available, requested)
+        if abs(diverted - taken) <= MATCH_TOL * scale
+    ]
+    if not slopes or max(slopes) - min(slopes) > MATCH_TOL:
+        return 0.0, False
+    return slopes[0], True
+
+
+def reach_coefficients(available, requested, taken):
+    """Return how the diversions of one reach share out its outflow.
+
+    The diversions are applied in turn, each taking from what the one before it
+    left, so the flow passed on carries the product of what each leaves behind.
+
+    Parameters
+    ----------
+    available : float
+        Flow the reach has to give before any diversion is taken.
+    requested : sequence of float
+        Rate each diversion is given, in the order they are applied.
+    taken : sequence of float
+        Flow each diversion actually took.
+
+    Returns
+    -------
+    tuple
+        The derivative of each diverted flow with respect to the flow the reach
+        had before any diversion, the derivative of the flow passed on, and
+        whether every rule was determined.
+    """
+    coefficients = np.zeros(len(requested))
+    remaining = 1.0
+    determined = True
+    for i, (rate, flow) in enumerate(zip(requested, taken)):
+        slope, known = diversion_derivative(available, rate, flow)
+        determined = determined and known
+        coefficients[i] = remaining * slope
+        remaining *= 1.0 - slope
+        available -= flow
+    return coefficients, remaining, determined


### PR DESCRIPTION
A diversion removes water from the flow a reach passes on under one of four rules, and the flow it took was held fixed with a warning because MODFLOW keeps the rule in a character array that is not in its memory store.

The rule does not have to be read. The flow available to a diversion, the rate it was given, and the flow it took are all recoverable, and those three determine the derivative: where two rules give the same diverted flow they also give the same derivative. Where the flows leave it open the diversion is reported and its flow held fixed, as before. Each rule then scales the routing coefficients the reach equations already build.

The share a reach passes on is now read from the total MODFLOW keeps, which leaves out both a diversion and an inactive reach, rather than summed from the upstream fractions, which counted a diversion in the denominator.

Holding the diverted flow fixed gave sensitivities in error by 0.03 to 0.11 percent under the three rules whose derivative is not zero; differentiating it brought all four to within 0.001 percent.

Closes the diversion half of #82. Stacked on #94.