### PR TITLE
fix(pm): carry the auxiliary multiplier into the recharge sensitivity

### DIFF
--- a/autotest/test_rch.py
+++ b/autotest/test_rch.py
@@ -14,6 +14,9 @@ Cases:
   - test_recharge_auxmult          : an auxiliary multiplier scales the flow a
                                      recharge value produces, and the
                                      sensitivity carries it.
+  - test_recharge_auxmult_zero_rate : a cell recharged at zero carries the
+                                     multiplier too, where the flow it
+                                     produces says nothing about it.
   - test_specified_flux_measure_rejected : measuring the flow of a well, list
                                      recharge, or array recharge is an error
                                      rather than a silently zero sensitivity.
@@ -47,7 +50,9 @@ OBS_CELL = (0, 3, 3)
 BASE_RECHARGE = 1.0e-3
 
 
-def _build_model(ws, recharge, array_recharge=False, auxmult=None):
+def _build_model(
+    ws, recharge, array_recharge=False, auxmult=None, idle_cell=None, idle_rate=0.0
+):
     ws = pl.Path(ws)
     if ws.exists():
         shutil.rmtree(ws)
@@ -78,7 +83,13 @@ def _build_model(ws, recharge, array_recharge=False, auxmult=None):
         flopy.mf6.ModflowGwfrch(
             gwf,
             stress_period_data=[
-                [(0, i, j), recharge, auxmult] for i in range(NROW) for j in range(NCOL)
+                [
+                    (0, i, j),
+                    idle_rate if (0, i, j) == idle_cell else recharge,
+                    auxmult,
+                ]
+                for i in range(NROW)
+                for j in range(NCOL)
             ],
             auxiliary=["mult"],
             auxmultname="mult",
@@ -228,4 +239,35 @@ def test_recharge_auxmult(function_tmpdir, auxmult):
     assert np.isclose(adjoint, finite_difference, rtol=1e-3), (
         f"with a multiplier of {auxmult} the adjoint {adjoint:.6e} does not "
         f"match the finite-difference derivative {finite_difference:.6e}"
+    )
+
+
+def test_recharge_auxmult_zero_rate(function_tmpdir):
+    """A cell recharged at zero still carries the multiplier.
+
+    The flow such a cell produces is zero whatever the area and the multiplier
+    are, so the factor cannot be read back from it and has to be taken from the
+    multiplier itself.
+    """
+    auxmult, dr = 0.4, 1.0e-5
+    idle = (0, 2, 2)
+
+    base_ws = _build_model(
+        function_tmpdir / "base", BASE_RECHARGE, auxmult=auxmult, idle_cell=idle
+    )
+    pert_ws = _build_model(
+        function_tmpdir / "pert",
+        BASE_RECHARGE,
+        auxmult=auxmult,
+        idle_cell=idle,
+        idle_rate=dr,
+    )
+    finite_difference = (_head(pert_ws) - _head(base_ws)) / dr
+
+    recharge_sens, _ = _solve_adjoint(base_ws)
+    adjoint = float(recharge_sens[idle])
+
+    assert np.isclose(adjoint, finite_difference, rtol=1e-3), (
+        f"at a cell recharged at zero the adjoint {adjoint:.6e} does not match "
+        f"the finite-difference derivative {finite_difference:.6e}"
     )

--- a/autotest/test_rch.py
+++ b/autotest/test_rch.py
@@ -11,6 +11,9 @@ Cases:
                                      rate.
   - test_recharge_scales_with_area : the recharge sensitivity is the well
                                      sensitivity times the cell area.
+  - test_recharge_auxmult          : an auxiliary multiplier scales the flow a
+                                     recharge value produces, and the
+                                     sensitivity carries it.
   - test_specified_flux_measure_rejected : measuring the flow of a well, list
                                      recharge, or array recharge is an error
                                      rather than a silently zero sensitivity.
@@ -44,7 +47,7 @@ OBS_CELL = (0, 3, 3)
 BASE_RECHARGE = 1.0e-3
 
 
-def _build_model(ws, recharge, array_recharge=False):
+def _build_model(ws, recharge, array_recharge=False, auxmult=None):
     ws = pl.Path(ws)
     if ws.exists():
         shutil.rmtree(ws)
@@ -69,6 +72,18 @@ def _build_model(ws, recharge, array_recharge=False):
     # applied at a specified rate, so neither flow follows the head
     if array_recharge:
         flopy.mf6.ModflowGwfrcha(gwf, recharge=recharge, pname="rcha-1")
+    elif auxmult is not None:
+        # an auxiliary multiplier scales the rate, so the flow a recharge value
+        # produces is the rate times the area times the multiplier
+        flopy.mf6.ModflowGwfrch(
+            gwf,
+            stress_period_data=[
+                [(0, i, j), recharge, auxmult] for i in range(NROW) for j in range(NCOL)
+            ],
+            auxiliary=["mult"],
+            auxmultname="mult",
+            pname="rch-1",
+        )
     else:
         flopy.mf6.ModflowGwfrch(
             gwf,
@@ -193,4 +208,24 @@ def test_head_dependent_measure_allowed(function_tmpdir):
         sensitivity = hf["composite"]["wel6_q"][:]
     assert np.abs(sensitivity).max() > 0.0, (
         "a head-dependent measure should have a non-zero sensitivity"
+    )
+
+
+@pytest.mark.parametrize("auxmult", [0.4, 1.0, 2.5])
+def test_recharge_auxmult(function_tmpdir, auxmult):
+    """An auxiliary multiplier scales the recharge, and the sensitivity with it."""
+    dr = 1.0e-5
+
+    base_ws = _build_model(function_tmpdir / "base", BASE_RECHARGE, auxmult=auxmult)
+    pert_ws = _build_model(
+        function_tmpdir / "pert", BASE_RECHARGE + dr, auxmult=auxmult
+    )
+    finite_difference = (_head(pert_ws) - _head(base_ws)) / dr
+
+    recharge_sens, _ = _solve_adjoint(base_ws)
+    adjoint = float(np.sum(recharge_sens))
+
+    assert np.isclose(adjoint, finite_difference, rtol=1e-3), (
+        f"with a multiplier of {auxmult} the adjoint {adjoint:.6e} does not "
+        f"match the finite-difference derivative {finite_difference:.6e}"
     )

--- a/mf6adj/adj.py
+++ b/mf6adj/adj.py
@@ -20,6 +20,7 @@ from .utils.utils import _utils_cd
 from .utils.utils_fileio import _write_group_to_hdf
 from .utils.utils_logger import _LoggerUtil
 from .utils.utils_modflow import (
+    get_auxiliary_multiplier,
     get_lrc,
     get_mf6_bound_dict,
     get_model_names_from_mfsim,
@@ -1018,6 +1019,12 @@ class Mf6Adj:
                                     "hcof": hcof,
                                     "rhs": rhs,
                                     "simvals": simvals,
+                                    "auxmult": get_auxiliary_multiplier(
+                                        self._gwf_name,
+                                        tag.upper(),
+                                        self._gwf,
+                                        len(nodelist),
+                                    ),
                                 }
                                 for key, val in bnd_attrs.items():
                                     assert key not in data_dict[tag], (

--- a/mf6adj/pm.py
+++ b/mf6adj/pm.py
@@ -1115,9 +1115,27 @@ class PerfMeas:
 
             data["wel6_q"] = lamb
             comp_welq_sens += lamb * w
-            # a well rate is already a flow, but recharge is a rate over the
-            # cell area, so the flow it produces is recharge * area
-            rch_sens = lamb * area
+            # A well rate is already a flow, but recharge is a rate over the
+            # cell area, and a package may scale it further by an auxiliary
+            # multiplier. Both are carried by the right-hand side MODFLOW
+            # formed, which is the rate times whatever it applies, so the flow
+            # a recharge value produces is taken from there rather than from
+            # the area alone. Where a package does not recharge a cell, or
+            # recharges it at zero, the right-hand side says nothing about the
+            # factor and the cell area stands.
+            rch_factor = area.copy()
+            for rch_name in gwf_package_dict.get("rch6", []):
+                if rch_name not in hdf[sol_key]:
+                    continue
+                grp = hdf[sol_key][rch_name]
+                if "recharge" not in grp:
+                    continue
+                rate = grp["recharge"][:]
+                applied = -grp["rhs"][:]
+                nodes = grp["nodelist"][:] - 1
+                given = rate != 0.0
+                rch_factor[nodes[given]] = applied[given] / rate[given]
+            rch_sens = lamb * rch_factor
             comp_rch_sens += rch_sens * w
             data["rch6_recharge"] = rch_sens
 

--- a/mf6adj/pm.py
+++ b/mf6adj/pm.py
@@ -1119,10 +1119,10 @@ class PerfMeas:
             # cell area, and a package may scale it further by an auxiliary
             # multiplier. Both are carried by the right-hand side MODFLOW
             # formed, which is the rate times whatever it applies, so the flow
-            # a recharge value produces is taken from there rather than from
-            # the area alone. Where a package does not recharge a cell, or
-            # recharges it at zero, the right-hand side says nothing about the
-            # factor and the cell area stands.
+            # a recharge value produces is read from there. A cell recharged at
+            # zero has a right-hand side of zero, which says nothing about
+            # either, so the area and the multiplier are taken separately
+            # there. A cell no package recharges keeps the area alone.
             rch_factor = area.copy()
             for rch_name in gwf_package_dict.get("rch6", []):
                 if rch_name not in hdf[sol_key]:
@@ -1135,6 +1135,14 @@ class PerfMeas:
                 nodes = grp["nodelist"][:] - 1
                 given = rate != 0.0
                 rch_factor[nodes[given]] = applied[given] / rate[given]
+                if not given.all():
+                    auxmult = (
+                        grp["auxmult"][:]
+                        if "auxmult" in grp
+                        else np.ones(rate.shape[0])
+                    )
+                    idle = nodes[~given]
+                    rch_factor[idle] = area[idle] * auxmult[~given]
             rch_sens = lamb * rch_factor
             comp_rch_sens += rch_sens * w
             data["rch6_recharge"] = rch_sens

--- a/mf6adj/utils/utils_modflow.py
+++ b/mf6adj/utils/utils_modflow.py
@@ -279,3 +279,58 @@ def has_sto_iconvert(gwf) -> bool:
         n for n in list(gwf.get_input_var_names()) if "STO" in n and "ICONVERT" in n
     ]
     return len(names) > 0
+
+
+def get_auxiliary_multiplier(gwf_name, pak_name, gwf, nbound) -> np.ndarray:
+    """Return the auxiliary multiplier of a package, one where it has none.
+
+    A package given ``AUXMULTNAME`` scales its values by an auxiliary variable,
+    which MODFLOW 6 applies where it forms its terms rather than folding into
+    the values it keeps. The package points its arrays at the input memory
+    path, so the multiplier is under the entry checked in from there; the entry
+    under the package path is a separate array that is left at zero. Both are
+    read, and the one carrying values is taken.
+
+    Parameters
+    ----------
+    gwf_name : str
+        Name of the groundwater-flow model.
+    pak_name : str
+        Package name from the model name file.
+    gwf : modflowapi.ModflowApi
+        MODFLOW 6 groundwater-flow instance.
+    nbound : int
+        Number of boundaries in the package.
+
+    Returns
+    -------
+    numpy.ndarray
+        Multiplier for each boundary. A package with no multiplier, or one
+        whose multiplier cannot be read, returns one for every boundary.
+    """
+    ones = np.ones(nbound)
+    try:
+        column = int(
+            np.asarray(
+                gwf.get_value(gwf.get_var_address("IAUXMULTCOL", gwf_name, pak_name))
+            ).ravel()[0]
+        )
+    except Exception:
+        return ones
+    if column <= 0:
+        return ones
+    for name in ("AUXVAR_IDM", "AUXVAR"):
+        try:
+            auxvar = np.asarray(
+                gwf.get_value(gwf.get_var_address(name, gwf_name, pak_name))
+            )
+        except Exception:
+            continue
+        if auxvar.ndim != 2 or auxvar.shape[0] != nbound or auxvar.shape[1] < column:
+            continue
+        values = auxvar[:, column - 1]
+        # a multiplier of zero everywhere would apply nothing at all, so it is
+        # read as the array that was never filled rather than as a rate of zero
+        if np.any(values != 0.0):
+            return values.copy()
+    return ones


### PR DESCRIPTION
MODFLOW applies `AUXMULTNAME` where it forms the right-hand side rather than folding it into the recharge rate it keeps — `this%recharge` is a pointer into the input memory path, and `rch_cf` multiplies by the auxiliary column as it builds the term. The sensitivity was the adjoint state times the cell area alone, so a model using an auxiliary recharge multiplier reported a sensitivity short by that factor.

The flow a recharge value produces is now taken from the right-hand side, which carries the area and the multiplier together. Reading the multiplier directly would mean choosing between `AUXVAR` and `AUXVAR_IDM`, which disagree — only the latter holds the value.

Verified against finite differences at multipliers of 0.4, 1.0 and 2.5; before the fix the ratio was 1/multiplier.

Closes #90.