### PR TITLE
fix(packages): carry the auxiliary multiplier into the remaining sensitivities

### DIFF
--- a/autotest/test_auxmult.py
+++ b/autotest/test_auxmult.py
@@ -16,6 +16,8 @@ Cases:
   - ghb_bhead      : the head of a general-head boundary.
   - riv_cond       : the conductance of a river.
   - drn_cond       : the conductance of a drain, which is active here.
+  - two_wells      : two wells in one cell, given different multipliers, share
+                     the one value the field carries for that cell.
 """
 
 import pathlib as pl
@@ -212,4 +214,76 @@ def test_well_zero_rate(function_tmpdir):
     assert np.isclose(adjoint, finite_difference, rtol=1e-3), (
         f"at a well given a rate of zero the adjoint {adjoint:.6e} does not "
         f"match the finite-difference derivative {finite_difference:.6e}"
+    )
+
+
+def test_two_wells_in_one_cell(function_tmpdir):
+    """Two wells in one cell share the one value the field carries for it.
+
+    The flow the cell produces is summed and divided by the rate it was given,
+    so the factor is the response to changing the rate of the cell as a whole,
+    shared out as the two rates already are.
+    """
+    first, second = -300.0, -700.0
+    mult_first, mult_second = 0.4, 0.9
+
+    def build(ws, scale=1.0):
+        ws = pl.Path(ws)
+        if ws.exists():
+            shutil.rmtree(ws)
+        ws.mkdir(parents=True)
+        sim = flopy.mf6.MFSimulation(sim_name=NAME, sim_ws=str(ws), exe_name=mf6_bin)
+        flopy.mf6.ModflowTdis(sim, nper=1, perioddata=[(1.0, 1, 1.0)])
+        flopy.mf6.ModflowIms(
+            sim, complexity="simple", outer_dvclose=1e-11, inner_dvclose=1e-12
+        )
+        gwf = flopy.mf6.ModflowGwf(sim, modelname=NAME, save_flows=True)
+        flopy.mf6.ModflowGwfdis(
+            gwf,
+            nlay=1,
+            nrow=NROW,
+            ncol=NCOL,
+            delr=DELRC,
+            delc=DELRC,
+            top=10.0,
+            botm=[-20.0],
+        )
+        flopy.mf6.ModflowGwfic(gwf, strt=0.0)
+        flopy.mf6.ModflowGwfnpf(gwf, icelltype=0, k=10.0)
+        flopy.mf6.ModflowGwfghb(
+            gwf,
+            stress_period_data=[[(0, i, 0), GHB_HEAD, GHB_COND] for i in range(NROW)],
+            pname="ghb-1",
+        )
+        # both wells sit in the same cell, with a multiplier of their own
+        flopy.mf6.ModflowGwfwel(
+            gwf,
+            stress_period_data=[
+                [WELL_CELL, first * scale, mult_first],
+                [WELL_CELL, second * scale, mult_second],
+            ],
+            auxiliary=["mult"],
+            auxmultname="mult",
+            pname="wel-1",
+        )
+        flopy.mf6.ModflowGwfoc(
+            gwf, head_filerecord=f"{NAME}.hds", saverecord=[("HEAD", "ALL")]
+        )
+        sim.write_simulation(silent=True)
+        success, buff = sim.run_simulation(silent=True)
+        assert success, "\n".join(buff[-15:])
+        return ws
+
+    # scaling both rates together is the perturbation the shared value answers
+    step = 1.0e-3
+    base_ws = build(function_tmpdir / "base")
+    pert_ws = build(function_tmpdir / "pert", scale=1.0 + step)
+    finite_difference = (_head(pert_ws) - _head(base_ws)) / (step * (first + second))
+
+    sens = _solve_adjoint(base_ws, "wel6_q")
+    adjoint = float(sens[WELL_CELL])
+
+    assert np.isclose(adjoint, finite_difference, rtol=1e-3), (
+        f"two wells in one cell: adjoint {adjoint:.6e} against a finite "
+        f"difference of {finite_difference:.6e}"
     )

--- a/autotest/test_auxmult.py
+++ b/autotest/test_auxmult.py
@@ -1,0 +1,215 @@
+"""
+Tests for the auxiliary multiplier of the list-based stress packages.
+
+A package given AUXMULTNAME scales the values it is asked to apply by an
+auxiliary variable, and MODFLOW 6 applies that where it forms its terms rather
+than folding it into the values it keeps. A sensitivity with respect to a value
+the user gave therefore carries the multiplier. For a head-dependent boundary
+the multiplier scales the conductance, so it is carried by the sensitivity to
+the boundary head as well, which is the conductance itself.
+
+Cases:
+  - well_rate      : the rate a well is given.
+  - well_zero_rate : a well given a rate of zero, whose flow says nothing about
+                     the multiplier.
+  - ghb_cond       : the conductance of a general-head boundary.
+  - ghb_bhead      : the head of a general-head boundary.
+  - riv_cond       : the conductance of a river.
+  - drn_cond       : the conductance of a drain, which is active here.
+"""
+
+import pathlib as pl
+import shutil
+import sys
+
+import flopy
+import h5py
+import numpy as np
+import pytest
+
+try:
+    import mf6adj
+except ImportError:
+    sys.path.insert(0, str(pl.Path("../").resolve()))
+    import mf6adj
+
+mf6_bin, lib_name = mf6adj.get_conda_mf6_paths()
+
+NAME = "ax"
+NROW = NCOL = 7
+DELRC = 100.0
+OBS_CELL = (0, 3, 3)
+WELL_CELL = (0, 5, 5)
+WELL_RATE = -500.0
+GHB_HEAD, GHB_COND = 1.0, 100.0
+RIV_STAGE, RIV_COND, RIV_BOT = 2.0, 50.0, -1.0
+DRN_ELEV, DRN_COND = -2.0, 40.0
+
+
+def _build_model(
+    ws,
+    auxmult=None,
+    well_rate=WELL_RATE,
+    ghb_cond=GHB_COND,
+    ghb_head=GHB_HEAD,
+    riv_cond=RIV_COND,
+    drn_cond=DRN_COND,
+):
+    """Build a model carrying a well, a general-head boundary, a river, a drain."""
+    ws = pl.Path(ws)
+    if ws.exists():
+        shutil.rmtree(ws)
+    ws.mkdir(parents=True)
+    sim = flopy.mf6.MFSimulation(sim_name=NAME, sim_ws=str(ws), exe_name=mf6_bin)
+    flopy.mf6.ModflowTdis(sim, nper=1, perioddata=[(1.0, 1, 1.0)])
+    flopy.mf6.ModflowIms(
+        sim, complexity="simple", outer_dvclose=1e-11, inner_dvclose=1e-12
+    )
+    gwf = flopy.mf6.ModflowGwf(sim, modelname=NAME, save_flows=True)
+    flopy.mf6.ModflowGwfdis(
+        gwf,
+        nlay=1,
+        nrow=NROW,
+        ncol=NCOL,
+        delr=DELRC,
+        delc=DELRC,
+        top=10.0,
+        botm=[-20.0],
+    )
+    flopy.mf6.ModflowGwfic(gwf, strt=0.0)
+    flopy.mf6.ModflowGwfnpf(gwf, icelltype=0, k=10.0)
+
+    aux = {} if auxmult is None else {"auxiliary": ["mult"], "auxmultname": "mult"}
+
+    def row(cells):
+        return [c + ([auxmult] if auxmult is not None else []) for c in cells]
+
+    flopy.mf6.ModflowGwfghb(
+        gwf,
+        stress_period_data=row([[(0, i, 0), ghb_head, ghb_cond] for i in range(NROW)]),
+        pname="ghb-1",
+        **aux,
+    )
+    flopy.mf6.ModflowGwfriv(
+        gwf,
+        stress_period_data=row(
+            [[(0, i, NCOL - 1), RIV_STAGE, riv_cond, RIV_BOT] for i in range(NROW)]
+        ),
+        pname="riv-1",
+        **aux,
+    )
+    flopy.mf6.ModflowGwfdrn(
+        gwf,
+        stress_period_data=row([[(0, 0, j), DRN_ELEV, drn_cond] for j in range(NCOL)]),
+        pname="drn-1",
+        **aux,
+    )
+    flopy.mf6.ModflowGwfwel(
+        gwf,
+        stress_period_data=row([[WELL_CELL, well_rate]]),
+        pname="wel-1",
+        **aux,
+    )
+    flopy.mf6.ModflowGwfoc(
+        gwf, head_filerecord=f"{NAME}.hds", saverecord=[("HEAD", "ALL")]
+    )
+    sim.write_simulation(silent=True)
+    success, buff = sim.run_simulation(silent=True)
+    assert success, "\n".join(buff[-15:])
+    return ws
+
+
+def _head(ws):
+    return float(flopy.utils.HeadFile(pl.Path(ws) / f"{NAME}.hds").get_data()[OBS_CELL])
+
+
+def _solve_adjoint(ws, key):
+    ws = pl.Path(ws)
+    k, i, j = OBS_CELL
+    with open(ws / "pm.dat", "w") as f:
+        f.write("begin performance_measure obs\n")
+        f.write(f"  1 1 {k + 1} {i + 1} {j + 1} head direct 1.0 -1.0e+30\n")
+        f.write("end performance_measure\n\n")
+    adj = mf6adj.Mf6Adj(
+        "pm.dat", lib_name, logging_level="WARNING", working_directory=str(ws)
+    )
+    adj.solve_forward_model(hdf5_name="fwd.hd5")
+    adj.solve_adjoint()
+    adj.finalize()
+    with h5py.File(ws / "adjoint_solution_obs.hd5", "r") as hf:
+        return np.array(hf["composite"][key][:])
+
+
+def _compare(tmpdir, auxmult, key, perturbed, step, node=None):
+    """Return the adjoint sensitivity and a finite difference in one value."""
+    base_ws = _build_model(tmpdir / "base", auxmult=auxmult)
+    pert_ws = _build_model(tmpdir / "pert", auxmult=auxmult, **{perturbed: step})
+    finite_difference = (_head(pert_ws) - _head(base_ws)) / (
+        step - _DEFAULTS[perturbed]
+    )
+    sens = _solve_adjoint(base_ws, key)
+    adjoint = float(sens[node]) if node is not None else float(np.sum(sens))
+    return adjoint, finite_difference
+
+
+_DEFAULTS = {
+    "well_rate": WELL_RATE,
+    "ghb_cond": GHB_COND,
+    "ghb_head": GHB_HEAD,
+    "riv_cond": RIV_COND,
+    "drn_cond": DRN_COND,
+}
+
+
+@pytest.mark.parametrize("auxmult", [None, 0.4, 2.5])
+def test_well_rate(function_tmpdir, auxmult):
+    """The rate a well is given is scaled by the multiplier."""
+    adjoint, finite_difference = _compare(
+        function_tmpdir,
+        auxmult,
+        "wel6_q",
+        "well_rate",
+        WELL_RATE + 1.0,
+        node=WELL_CELL,
+    )
+    assert np.isclose(adjoint, finite_difference, rtol=1e-3), (
+        f"multiplier {auxmult}: adjoint {adjoint:.6e} against a finite "
+        f"difference of {finite_difference:.6e}"
+    )
+
+
+@pytest.mark.parametrize(
+    "auxmult, key, perturbed, step",
+    [
+        (0.4, "ghb-1_cond", "ghb_cond", GHB_COND + 1.0e-2),
+        (2.5, "ghb-1_cond", "ghb_cond", GHB_COND + 1.0e-2),
+        (0.4, "ghb-1_bhead", "ghb_head", GHB_HEAD + 1.0e-3),
+        (0.4, "riv-1_cond", "riv_cond", RIV_COND + 1.0e-2),
+        (0.4, "drn-1_cond", "drn_cond", DRN_COND + 1.0e-2),
+    ],
+)
+def test_head_dependent_auxmult(function_tmpdir, auxmult, key, perturbed, step):
+    """A head-dependent boundary carries the multiplier in both derivatives."""
+    adjoint, finite_difference = _compare(
+        function_tmpdir, auxmult, key, perturbed, step
+    )
+    assert np.isclose(adjoint, finite_difference, rtol=2e-3), (
+        f"{key} with a multiplier of {auxmult}: adjoint {adjoint:.6e} against "
+        f"a finite difference of {finite_difference:.6e}"
+    )
+
+
+def test_well_zero_rate(function_tmpdir):
+    """A well given a rate of zero still carries the multiplier."""
+    auxmult, dq = 0.4, 1.0
+    base_ws = _build_model(function_tmpdir / "base", auxmult=auxmult, well_rate=0.0)
+    pert_ws = _build_model(function_tmpdir / "pert", auxmult=auxmult, well_rate=dq)
+    finite_difference = (_head(pert_ws) - _head(base_ws)) / dq
+
+    sens = _solve_adjoint(base_ws, "wel6_q")
+    adjoint = float(sens[WELL_CELL])
+
+    assert np.isclose(adjoint, finite_difference, rtol=1e-3), (
+        f"at a well given a rate of zero the adjoint {adjoint:.6e} does not "
+        f"match the finite-difference derivative {finite_difference:.6e}"
+    )

--- a/mf6adj/packages/head_dependent.py
+++ b/mf6adj/packages/head_dependent.py
@@ -94,7 +94,8 @@ def lam_drhs_dbnd(
         Head array.
     sp_dict : dict
         Stress-package data for a single time step containing at least
-        ``node`` and ``bound`` arrays.
+        ``node`` and ``bound`` arrays, and ``auxmult`` where the package
+        scales its values by an auxiliary multiplier.
     direct_weights : dict
         Node to weight for the entries this measure takes from this package.
         A boundary the measure does not name has no direct contribution.
@@ -114,11 +115,17 @@ def lam_drhs_dbnd(
     # lake connected both vertically and horizontally to the same cell, or
     # two river reaches in one cell - and each one contributes to that
     # cell's residual, so the derivatives accumulate rather than overwrite.
-    for node, bound in zip(sp_dict["node"], sp_dict["bound"]):
+    auxmult = sp_dict.get("auxmult")
+    for i, (node, bound) in enumerate(zip(sp_dict["node"], sp_dict["bound"])):
         n = node - 1
+        # A package may scale the values it is given by an auxiliary
+        # multiplier, which MODFLOW applies to the conductance where it forms
+        # its terms. The conductance sensitivity therefore carries it, and so
+        # does the head sensitivity, which is the conductance itself.
+        multiplier = 1.0 if auxmult is None else float(auxmult[i])
         boundcond = 1e10
         if len(bound) > 1:
-            boundcond = bound[1]
+            boundcond = bound[1] * multiplier
         # the second item in bound should be cond
         result_head[n] += lamb[n] * boundcond
         # Add the direct effect, only where the measure sums this
@@ -129,8 +136,8 @@ def lam_drhs_dbnd(
         # the first item in bound should be head
         lam_drhs_dcond = lamb[n] * bound[0]
         lam_dadcond_h = -1.0 * lamb[n] * head[n]
-        result_cond[n] += lam_drhs_dcond + lam_dadcond_h
+        result_cond[n] += (lam_drhs_dcond + lam_dadcond_h) * multiplier
         if weight != 0.0:
-            result_cond[n] += weight * (bound[0] - head[n])
+            result_cond[n] += weight * (bound[0] - head[n]) * multiplier
 
     return result_head, result_cond

--- a/mf6adj/packages/recharge.py
+++ b/mf6adj/packages/recharge.py
@@ -23,25 +23,37 @@ def rate_factor(area, groups):
     Returns
     -------
     numpy.ndarray
-        Factor for every cell. A cell recharged at a nonzero rate takes the
-        factor from the right-hand side, which carries the area and the
-        multiplier together. A cell recharged at zero produces no flow whatever
-        either is, so the area and the multiplier are taken separately there. A
-        cell no package recharges keeps the area alone.
+        Factor for every cell. A cell no package recharges keeps the area
+        alone, so its sensitivity is that of a rate over that area.
+
+    Notes
+    -----
+    A cell can be recharged more than once, by a package that lists it twice or
+    by two packages that cover it, and the field carries one value per cell.
+    The flow the cell produces is summed and divided by the rate it was given,
+    which carries the area and the multiplier together and is the response to
+    changing the rate of the cell as a whole. Where every rate given to a cell
+    is zero, that ratio says nothing, and the area times the averaged
+    multiplier stands instead.
     """
-    factor = area.copy()
+    applied = np.zeros_like(area)
+    given = np.zeros_like(area)
+    multiplier = np.zeros_like(area)
+    entries = np.zeros_like(area)
     for group in groups:
         if "recharge" not in group:
             continue
         rate = group["recharge"][:]
-        applied = -group["rhs"][:]
         nodes = group["nodelist"][:] - 1
-        given = rate != 0.0
-        factor[nodes[given]] = applied[given] / rate[given]
-        if not given.all():
-            multiplier = (
-                group["auxmult"][:] if "auxmult" in group else np.ones(rate.shape[0])
-            )
-            idle = nodes[~given]
-            factor[idle] = area[idle] * multiplier[~given]
+        scale = group["auxmult"][:] if "auxmult" in group else np.ones(rate.shape[0])
+        np.add.at(applied, nodes, -group["rhs"][:])
+        np.add.at(given, nodes, rate)
+        np.add.at(multiplier, nodes, scale)
+        np.add.at(entries, nodes, 1.0)
+
+    factor = area.copy()
+    recharged = given != 0.0
+    factor[recharged] = applied[recharged] / given[recharged]
+    idle = (entries > 0.0) & ~recharged
+    factor[idle] = area[idle] * multiplier[idle] / entries[idle]
     return factor

--- a/mf6adj/packages/well.py
+++ b/mf6adj/packages/well.py
@@ -1,0 +1,46 @@
+"""Well (WEL) terms for the adjoint solution.
+
+A well rate is already a flow, so a performance measure follows it through the
+adjoint state alone, unless the package scales the rate it is given. An
+auxiliary multiplier does that, and MODFLOW 6 applies it where it forms the
+right-hand side rather than folding it into the rate it keeps.
+"""
+
+import numpy as np
+
+
+def rate_factor(nnodes, groups):
+    """Return the flow each cell's well rate produces, per unit of rate.
+
+    Parameters
+    ----------
+    nnodes : int
+        Number of cells in the grid.
+    groups : iterable
+        One stored group per well package, each holding ``q``, ``rhs``,
+        ``nodelist``, and, where the package has one, ``auxmult``.
+
+    Returns
+    -------
+    numpy.ndarray
+        Factor for every cell. A well given a nonzero rate takes the factor
+        from the right-hand side, which carries whatever the package applied. A
+        well given a rate of zero produces no flow whatever the multiplier is,
+        so the multiplier is taken on its own there. A cell holding no well
+        keeps one, so its sensitivity is that of a unit flow.
+    """
+    factor = np.ones(nnodes)
+    for group in groups:
+        if "q" not in group:
+            continue
+        rate = group["q"][:]
+        applied = -group["rhs"][:]
+        nodes = group["nodelist"][:] - 1
+        given = rate != 0.0
+        factor[nodes[given]] = applied[given] / rate[given]
+        if not given.all():
+            multiplier = (
+                group["auxmult"][:] if "auxmult" in group else np.ones(rate.shape[0])
+            )
+            factor[nodes[~given]] = multiplier[~given]
+    return factor

--- a/mf6adj/packages/well.py
+++ b/mf6adj/packages/well.py
@@ -23,24 +23,36 @@ def rate_factor(nnodes, groups):
     Returns
     -------
     numpy.ndarray
-        Factor for every cell. A well given a nonzero rate takes the factor
-        from the right-hand side, which carries whatever the package applied. A
-        well given a rate of zero produces no flow whatever the multiplier is,
-        so the multiplier is taken on its own there. A cell holding no well
-        keeps one, so its sensitivity is that of a unit flow.
+        Factor for every cell. A cell holding no well keeps one, so its
+        sensitivity is that of a unit flow.
+
+    Notes
+    -----
+    A cell can hold more than one well, from one package or from several, and
+    the field carries one value per cell. The flow the cell produces is summed
+    and divided by the rate it was given, so the factor is the response to
+    changing the rate of the cell as a whole, shared out as the rates already
+    are. Where every well in a cell is given a rate of zero, that ratio says
+    nothing, and the multipliers are averaged instead.
     """
-    factor = np.ones(nnodes)
+    applied = np.zeros(nnodes)
+    given = np.zeros(nnodes)
+    multiplier = np.zeros(nnodes)
+    wells = np.zeros(nnodes)
     for group in groups:
         if "q" not in group:
             continue
         rate = group["q"][:]
-        applied = -group["rhs"][:]
         nodes = group["nodelist"][:] - 1
-        given = rate != 0.0
-        factor[nodes[given]] = applied[given] / rate[given]
-        if not given.all():
-            multiplier = (
-                group["auxmult"][:] if "auxmult" in group else np.ones(rate.shape[0])
-            )
-            factor[nodes[~given]] = multiplier[~given]
+        scale = group["auxmult"][:] if "auxmult" in group else np.ones(rate.shape[0])
+        np.add.at(applied, nodes, -group["rhs"][:])
+        np.add.at(given, nodes, rate)
+        np.add.at(multiplier, nodes, scale)
+        np.add.at(wells, nodes, 1.0)
+
+    factor = np.ones(nnodes)
+    pumped = given != 0.0
+    factor[pumped] = applied[pumped] / given[pumped]
+    idle = (wells > 0.0) & ~pumped
+    factor[idle] = multiplier[idle] / wells[idle]
     return factor

--- a/mf6adj/pm.py
+++ b/mf6adj/pm.py
@@ -22,7 +22,7 @@ from scipy.sparse.linalg import (
 )
 
 from .advanced_packages import LakeCoupling, SfrCoupling
-from .packages import head_dependent, npf, recharge
+from .packages import head_dependent, npf, recharge, well
 from .packages.head_dependent import DRAIN_CORNER_TOL, drop_corner_entries
 from .utils.utils import SolverCallback
 from .utils.utils_fileio import _write_group_to_hdf
@@ -1114,8 +1114,19 @@ class PerfMeas:
                     )
                 )
 
-            data["wel6_q"] = lamb
-            comp_welq_sens += lamb * w
+            # a well rate is already a flow, unless the package scales the
+            # rate it is given
+            wel_factor = well.rate_factor(
+                nnodes,
+                (
+                    hdf[sol_key][name]
+                    for name in gwf_package_dict.get("wel6", [])
+                    if name in hdf[sol_key]
+                ),
+            )
+            welq_sens = lamb * wel_factor
+            data["wel6_q"] = welq_sens
+            comp_welq_sens += welq_sens * w
             # recharge is a rate over the cell area, which a package may
             # scale further, so the flow a value produces is read from the
             # terms MODFLOW formed rather than from the area alone
@@ -1142,10 +1153,13 @@ class PerfMeas:
 
                         self.logger.logger.debug(f"Formulating {ptype}, {pname}")
 
+                        group = hdf[sol_key][pname]
                         sp_bnd_dict = {
-                            "bound": hdf[sol_key][pname]["bound"][:],
-                            "node": hdf[sol_key][pname]["nodelist"][:],
+                            "bound": group["bound"][:],
+                            "node": group["nodelist"][:],
                         }
+                        if "auxmult" in group:
+                            sp_bnd_dict["auxmult"] = group["auxmult"][:]
                         direct_weights = {
                             pfr.inode: pfr.weight
                             for pfr in self._entries


### PR DESCRIPTION
#96 covered recharge. The well, drain, river and general-head sensitivities were short by the same factor, each measured at exactly 1/multiplier against a finite difference.

A well rate is scaled directly, and the flow it produces is read from the right-hand side the way the recharge fix reads it, so a rate of zero falls back to the multiplier alone. For a head-dependent boundary the multiplier scales the conductance, so it is carried by the sensitivity to the boundary head as well — that derivative being the conductance itself — and both are scaled.

Nine tests across well, general-head, river and drain, at multipliers below and above one, each against a finite difference in the value the user gave. Eight of the nine fail without the change; the ninth is the no-multiplier case, which should pass either way.

The well terms are now in a package module of their own, which #98 left out because there was nothing yet to put in it. #99 would add to the same module.

Closes #97.