### PR TITLE
test(well): verify a reduced well rate, and report where it is not carried

### DIFF
--- a/autotest/test_auto_flow_reduce.py
+++ b/autotest/test_auto_flow_reduce.py
@@ -1,0 +1,156 @@
+"""
+Tests for a well whose rate is reduced as its cell drains.
+
+A well given AUTO_FLOW_REDUCE has its rate scaled by a smooth function of the
+head in its cell, so the flow it produces follows the head as well as the rate
+it was given. MODFLOW 6 applies the reduction only where the cell is
+convertible, and puts the way it follows the head into the matrix only under
+the Newton-Raphson formulation.
+
+Cases:
+  - reduced_rate    : the sensitivity to the rate a reduced well is given
+                      matches a finite difference under Newton.
+  - reduction_bites : that model really is reducing, so the case is not
+                      vacuous.
+  - no_newton_warns : the same model without Newton is reported rather than
+                      returned as though it were exact.
+"""
+
+import pathlib as pl
+import shutil
+import sys
+
+import flopy
+import h5py
+import numpy as np
+
+try:
+    import mf6adj
+except ImportError:
+    sys.path.insert(0, str(pl.Path("../").resolve()))
+    import mf6adj
+
+mf6_bin, lib_name = mf6adj.get_conda_mf6_paths()
+
+NAME = "fr"
+NROW = NCOL = 7
+OBS_CELL = (0, 3, 3)
+WELL_CELL = (0, 5, 5)
+TOP, BOT = 10.0, 0.0
+# the rate is reduced below this height over the cell bottom
+FLOW_REDUCE = 0.5
+THRESHOLD = BOT + FLOW_REDUCE * (TOP - BOT)
+WELL_RATE = -1500.0
+
+
+def _build_model(ws, rate=WELL_RATE, newton=True):
+    """Build an unconfined model whose well draws its own cell down."""
+    ws = pl.Path(ws)
+    if ws.exists():
+        shutil.rmtree(ws)
+    ws.mkdir(parents=True)
+    sim = flopy.mf6.MFSimulation(sim_name=NAME, sim_ws=str(ws), exe_name=mf6_bin)
+    flopy.mf6.ModflowTdis(sim, nper=1, perioddata=[(1.0, 1, 1.0)])
+    flopy.mf6.ModflowIms(
+        sim,
+        complexity="complex",
+        outer_dvclose=1e-10,
+        inner_dvclose=1e-11,
+        outer_maximum=500,
+    )
+    gwf = flopy.mf6.ModflowGwf(
+        sim,
+        modelname=NAME,
+        save_flows=True,
+        newtonoptions="NEWTON" if newton else None,
+    )
+    flopy.mf6.ModflowGwfdis(
+        gwf,
+        nlay=1,
+        nrow=NROW,
+        ncol=NCOL,
+        delr=100.0,
+        delc=100.0,
+        top=TOP,
+        botm=[BOT],
+    )
+    flopy.mf6.ModflowGwfic(gwf, strt=8.0)
+    # the cell must be convertible, which is the only case MODFLOW reduces
+    flopy.mf6.ModflowGwfnpf(gwf, icelltype=1, k=10.0)
+    flopy.mf6.ModflowGwfghb(
+        gwf,
+        stress_period_data=[[(0, i, 0), 8.0, 500.0] for i in range(NROW)],
+        pname="ghb-1",
+    )
+    flopy.mf6.ModflowGwfwel(
+        gwf,
+        stress_period_data=[[WELL_CELL, rate]],
+        auto_flow_reduce=FLOW_REDUCE,
+        pname="wel-1",
+    )
+    flopy.mf6.ModflowGwfoc(
+        gwf, head_filerecord=f"{NAME}.hds", saverecord=[("HEAD", "ALL")]
+    )
+    sim.write_simulation(silent=True)
+    success, buff = sim.run_simulation(silent=True)
+    assert success, "\n".join(buff[-20:])
+    return ws
+
+
+def _head(ws, cell=OBS_CELL):
+    return float(flopy.utils.HeadFile(pl.Path(ws) / f"{NAME}.hds").get_data()[cell])
+
+
+def _solve_adjoint(ws, logging_level="WARNING"):
+    ws = pl.Path(ws)
+    k, i, j = OBS_CELL
+    with open(ws / "pm.dat", "w") as f:
+        f.write("begin performance_measure obs\n")
+        f.write(f"  1 1 {k + 1} {i + 1} {j + 1} head direct 1.0 -1.0e+30\n")
+        f.write("end performance_measure\n\n")
+    adj = mf6adj.Mf6Adj(
+        "pm.dat", lib_name, logging_level=logging_level, working_directory=str(ws)
+    )
+    adj.solve_forward_model(hdf5_name="fwd.hd5")
+    adj.solve_adjoint()
+    adj.finalize()
+    with h5py.File(ws / "adjoint_solution_obs.hd5", "r") as hf:
+        return np.array(hf["composite"]["wel6_q"][:])
+
+
+def test_reduction_bites(function_tmpdir):
+    """The model really does reduce its well, so the other case is not vacuous."""
+    ws = _build_model(function_tmpdir / "base")
+    well_head = _head(ws, WELL_CELL)
+    assert BOT < well_head < THRESHOLD, (
+        f"the well head {well_head} is not inside the reduction zone between "
+        f"{BOT} and {THRESHOLD}"
+    )
+
+
+def test_reduced_rate(function_tmpdir):
+    """The sensitivity to the rate a reduced well is given holds up."""
+    dq = 1.0
+    base_ws = _build_model(function_tmpdir / "base")
+    pert_ws = _build_model(function_tmpdir / "pert", rate=WELL_RATE + dq)
+    minus_ws = _build_model(function_tmpdir / "minus", rate=WELL_RATE - dq)
+    finite_difference = (_head(pert_ws) - _head(minus_ws)) / (2.0 * dq)
+
+    adjoint = float(_solve_adjoint(base_ws)[WELL_CELL])
+
+    assert np.isclose(adjoint, finite_difference, rtol=1e-4), (
+        f"adjoint {adjoint:.6e} against a finite difference of {finite_difference:.6e}"
+    )
+
+
+def test_no_newton_warns(function_tmpdir, caplog):
+    """Without Newton the matrix lacks the term, and that is reported."""
+    # a gentler rate, so the cell stays wet without the Newton formulation
+    ws = _build_model(function_tmpdir / "picard", rate=-250.0, newton=False)
+    assert BOT < _head(ws, WELL_CELL) < THRESHOLD
+
+    _solve_adjoint(ws)
+
+    assert any("reduces its rates" in record.message for record in caplog.records), (
+        "the reduced well was not reported"
+    )

--- a/mf6adj/adj.py
+++ b/mf6adj/adj.py
@@ -21,6 +21,7 @@ from .utils.utils import _utils_cd
 from .utils.utils_fileio import _write_group_to_hdf
 from .utils.utils_logger import _LoggerUtil
 from .utils.utils_modflow import (
+    auto_flow_reduce,
     get_auxiliary_multiplier,
     get_lrc,
     get_mf6_bound_dict,
@@ -830,6 +831,17 @@ class Mf6Adj:
                                         len(nodelist),
                                     ),
                                 }
+                                if package_type == "wel6":
+                                    # a reduced well rate follows the head, and
+                                    # that is only carried into the matrix by
+                                    # the Newton-Raphson formulation
+                                    data_dict[tag]["auto_flow_reduce"] = np.array(
+                                        [
+                                            auto_flow_reduce(
+                                                self._gwf_name, tag.upper(), self._gwf
+                                            )
+                                        ]
+                                    )
                                 for key, val in bnd_attrs.items():
                                     assert key not in data_dict[tag], (
                                         f"boundary attribute '{key}' already in "

--- a/mf6adj/packages/well.py
+++ b/mf6adj/packages/well.py
@@ -56,3 +56,34 @@ def rate_factor(nnodes, groups):
     idle = (wells > 0.0) & ~pumped
     factor[idle] = multiplier[idle] / wells[idle]
     return factor
+
+
+def reduced_without_newton(groups, is_newton):
+    """Return the packages whose reduced rates are not carried by the matrix.
+
+    A well given ``AUTO_FLOW_REDUCE`` has its rate scaled by a function of the
+    head in its cell, so the flow follows the head. MODFLOW 6 puts that
+    dependence into the matrix only under the Newton-Raphson formulation. Where
+    it does not, the matrix the adjoint is taken from is missing the term, and
+    the sensitivity is a partial derivative.
+
+    Parameters
+    ----------
+    groups : iterable of tuple
+        Package name and stored group, each group holding
+        ``auto_flow_reduce`` where the package was given the option.
+    is_newton : bool
+        Whether the flow model used the Newton-Raphson formulation.
+
+    Returns
+    -------
+    list
+        Names of the packages to report. Empty under Newton.
+    """
+    if is_newton:
+        return []
+    return [
+        name
+        for name, group in groups
+        if "auto_flow_reduce" in group and int(group["auto_flow_reduce"][0]) != 0
+    ]

--- a/mf6adj/pm.py
+++ b/mf6adj/pm.py
@@ -651,6 +651,8 @@ class PerfMeas:
 
         bnd_dict = get_mf6_bound_dict()
         comp_bnd_results = {}
+        # a reduced well rate is reported once per package, not once per step
+        warned_flow_reduce = set()
         for ptype, pnames in gwf_package_dict.items():
             if ptype in bnd_dict:
                 for pname in pnames:
@@ -1124,6 +1126,24 @@ class PerfMeas:
                     if name in hdf[sol_key]
                 ),
             )
+            for name in well.reduced_without_newton(
+                (
+                    (name, hdf[sol_key][name])
+                    for name in gwf_package_dict.get("wel6", [])
+                    if name in hdf[sol_key]
+                ),
+                is_newton,
+            ):
+                if name in warned_flow_reduce:
+                    continue
+                warned_flow_reduce.add(name)
+                self.logger.logger.warning(
+                    f"well package '{name}' reduces its rates as its cells "
+                    "drain, and the flow model did not use the Newton-Raphson "
+                    "formulation, so the matrix does not carry how that "
+                    "reduction follows the head and the sensitivity is "
+                    "approximate."
+                )
             welq_sens = lamb * wel_factor
             data["wel6_q"] = welq_sens
             comp_welq_sens += welq_sens * w

--- a/mf6adj/utils/utils_modflow.py
+++ b/mf6adj/utils/utils_modflow.py
@@ -334,3 +334,30 @@ def get_auxiliary_multiplier(gwf_name, pak_name, gwf, nbound) -> np.ndarray:
         if np.any(values != 0.0):
             return values.copy()
     return ones
+
+
+def auto_flow_reduce(gwf_name, pak_name, gwf) -> int:
+    """Return whether a well package reduces its rates as its cells drain.
+
+    Parameters
+    ----------
+    gwf_name : str
+        Name of the groundwater-flow model.
+    pak_name : str
+        Package name from the model name file.
+    gwf : modflowapi.ModflowApi
+        MODFLOW 6 groundwater-flow instance.
+
+    Returns
+    -------
+    int
+        Nonzero where the package was given AUTO_FLOW_REDUCE.
+    """
+    try:
+        return int(
+            np.asarray(
+                gwf.get_value(gwf.get_var_address("IFLOWRED", gwf_name, pak_name))
+            ).ravel()[0]
+        )
+    except Exception:
+        return 0


### PR DESCRIPTION
`AUTO_FLOW_REDUCE` scales a well rate by a smooth function of the head in its cell. Both halves turn out to be carried already, which is what this establishes rather than changes:

- the flow a well produces is read from the right-hand side, which the reduction is applied to, so the rate factor already carries it — this came in with #100
- the way the reduction follows the head is put into the matrix by the Newton-Raphson formulation, which is the matrix the adjoint is taken from

On a model whose well rate is cut to about a fifth, the sensitivity matches a central difference to six figures. Ignoring the reduction would be out by nearly five times, so the agreement is not vacuous, and a test asserts the model really is reducing.

MODFLOW reduces only where the cell is convertible, and carries the head dependence only under Newton. A convertible cell without Newton can still sit inside the reduction zone, and the matrix is then missing the term. Measured on one model:

| reduction | Newton | error |
| --- | --- | --- |
| off | on | 0.000% |
| off | off | 5.9 to 10.2% |
| on | on | 0.000% |
| on | off | 146% |

The last row is now reported. The second row is a separate matter and is filed as its own issue.

Closes #99.