### PR TITLE
feat(adj): report a model whose matrix is not the derivative of its equations

### DIFF
--- a/autotest/test_auto_flow_reduce.py
+++ b/autotest/test_auto_flow_reduce.py
@@ -14,6 +14,9 @@ Cases:
                       vacuous.
   - no_newton_warns : the same model without Newton is reported rather than
                       returned as though it were exact.
+  - picard_warns    : a convertible cell without Newton is reported on its own
+                      account, whatever the wells are doing.
+  - newton_quiet    : neither is reported where the model used Newton.
 """
 
 import pathlib as pl
@@ -154,3 +157,26 @@ def test_no_newton_warns(function_tmpdir, caplog):
     assert any("reduces its rates" in record.message for record in caplog.records), (
         "the reduced well was not reported"
     )
+
+
+def test_picard_warns(function_tmpdir, caplog):
+    """A convertible cell without Newton is reported on its own account.
+
+    The matrix leaves out how the transmissivity follows the head, which is a
+    limitation of the model formulation rather than of any one package.
+    """
+    ws = _build_model(function_tmpdir / "picard", rate=-250.0, newton=False)
+    _solve_adjoint(ws)
+    assert any("convertible cells" in record.message for record in caplog.records), (
+        "the standard formulation was not reported"
+    )
+
+
+def test_newton_quiet(function_tmpdir, caplog):
+    """Neither condition is reported where the flow model used Newton."""
+    ws = _build_model(function_tmpdir / "newton")
+    _solve_adjoint(ws)
+    assert not any(
+        "convertible cells" in record.message or "reduces its rates" in record.message
+        for record in caplog.records
+    ), "an exact model was reported as approximate"

--- a/docs/SuppInfo/body.tex
+++ b/docs/SuppInfo/body.tex
@@ -6,6 +6,10 @@
 \label{ch:instantaneous}
 \input{instantaneous.tex}
 
+\chapter{Formulation and Exactness}
+\label{ch:formulation}
+\input{formulation.tex}
+
 \chapter{Storage}
 \label{ch:storage}
 \input{storage.tex}

--- a/docs/SuppInfo/formulation.tex
+++ b/docs/SuppInfo/formulation.tex
@@ -1,0 +1,57 @@
+The adjoint solution is taken from the matrix \mf{} assembled while it solved the flow model. Whether that matrix is the derivative of the flow equations, or only the operator used to iterate toward their solution, depends on the formulation the flow model was run under. This chapter describes when a sensitivity is exact, when it is a partial derivative, and what \adj{} reports.
+
+\section*{Two matrices}
+
+A cell that converts between confined and unconfined carries a transmissivity that follows the head, because the saturated thickness does. Writing the flow between cells $n$ and $m$ as
+
+\begin{equation}
+	\label{eqn:formulation-flow}
+	Q_{nm} = C_{nm}(h)\left( h_{m} - h_{n} \right),
+\end{equation}
+
+\noindent where $C_{nm}$ is the conductance between the two cells (L$^{2}$T$^{-1}$), the derivative of the residual with respect to the head carries two terms,
+
+\begin{equation}
+	\label{eqn:formulation-jacobian}
+	\frac{\partial r_{n}}{\partial h_{n}} = -\sum_{m} C_{nm}
+	+ \sum_{m} \frac{\partial C_{nm}}{\partial h_{n}}
+	\left( h_{m} - h_{n} \right).
+\end{equation}
+
+Under the Newton-Raphson formulation \mf{} assembles both terms of equation~\ref{eqn:formulation-jacobian}, because that is what the method requires. Under the standard formulation it assembles only the first and lags the second, recomputing the conductance between iterations until the heads stop moving. Both converge to a solution of the same physical problem, but only the first leaves behind a matrix that is the derivative of the equations.
+
+The adjoint needs that derivative. Given the first term alone it returns a partial derivative, holding the transmissivity fixed in the same way that holding a lake stage fixed returns a partial derivative (Chapter~\ref{ch:lake}).
+
+\section*{How far it is out}
+
+A single-layer unconfined model was pumped by a well against a general-head boundary, and the sensitivity of a head to the well rate compared with a central difference. The model was run twice at each rate, once under each formulation.
+
+\begin{table}[htb]
+	\centering
+	\caption{Error in the sensitivity of a head to a well rate, against a
+	finite-difference derivative, under each formulation.}
+	\label{tab:formulation}
+	\small
+	\begin{tabular}{lrr}
+		\toprule
+		\shortstack[l]{Head in the\\pumped cell} &
+		\shortstack[r]{Newton-\\Raphson} &
+		\shortstack[r]{Standard\\formulation} \\
+		\midrule
+		5.46 & 0.000\% & 5.9\%   \\
+		2.20 & 0.000\% & 10.2\%  \\
+		\bottomrule
+	\end{tabular}
+\end{table}
+
+The error under the standard formulation grows as the cell empties, which is what the neglected term in equation~\ref{eqn:formulation-jacobian} would give: the conductance follows the head most steeply where the saturated thickness is least. A confined model is unaffected, because there the conductance does not follow the head at all and the two matrices are the same.
+
+A second head-dependent term compounds this. A well given \texttt{AUTO\_FLOW\_REDUCE} has its rate scaled by a smooth function of the head in its cell, and that dependence is likewise carried into the matrix only under the Newton-Raphson formulation. On the same model the sensitivity was in error by 146 percent with the reduction active and the standard formulation in use, against 10 percent for the same model with no reduction at all. Under the Newton-Raphson formulation the reduced well is exact, matching a central difference to six figures, where neglecting the reduction entirely would be out by a factor of nearly five.
+
+\section*{What is reported}
+
+\adj{} reports a flow model that has convertible cells and was not run under the Newton-Raphson formulation, and reports a reduced well separately, rather than returning either as though it were exact. Neither is reported for a model run under Newton-Raphson, where both are carried.
+
+\section*{Limitation}
+
+The neglected term is not recovered. It cannot be taken from the Newton-Raphson assembly, because the two formulations do not solve the same discrete equations: the Newton-Raphson formulation weights the conductance upstream, and the converged heads of the two runs differ. Recovering it means differentiating the conductance the standard formulation actually used, which is one of three cell-averaging schemes, over horizontal, vertical, and vertically staggered connections. Running the flow model under the Newton-Raphson formulation is the shorter path to an exact sensitivity, and is what \adj{} recommends where it reports the condition.

--- a/docs/SuppInfo/mf6adjsuppinfo.tex
+++ b/docs/SuppInfo/mf6adjsuppinfo.tex
@@ -17,6 +17,10 @@
   citecolor={blue!50!black}, urlcolor={blue!80!black}}
 \newcolumntype{L}[1]{>{\raggedright\arraybackslash}p{#1}}
 
+% a caption sits above a table, and the class leaves no gap below it
+\setlength{\belowcaptionskip}{8pt}
+\setlength{\abovecaptionskip}{12pt}
+
 \bibliographystyle{groundwater}
 
 % shorthand used throughout the chapters

--- a/mf6adj/adj.py
+++ b/mf6adj/adj.py
@@ -22,6 +22,7 @@ from .utils.utils_fileio import _write_group_to_hdf
 from .utils.utils_logger import _LoggerUtil
 from .utils.utils_modflow import (
     auto_flow_reduce,
+    convertible_cells,
     get_auxiliary_multiplier,
     get_lrc,
     get_mf6_bound_dict,
@@ -517,6 +518,19 @@ class Mf6Adj:
             is_newton = self._gwf.get_value(
                 self._gwf.get_var_address("INEWTON", self._gwf_name)
             )[0]
+            # The adjoint is taken from the matrix MODFLOW assembled. Under the
+            # Newton-Raphson formulation that matrix is the Jacobian. Without
+            # it the matrix leaves out how the transmissivity of a convertible
+            # cell follows the head, and the sensitivity is a partial
+            # derivative that grows worse as the cell empties.
+            if not is_newton and convertible_cells(self._gwf_name, self._gwf):
+                self.logger.logger.warning(
+                    "the flow model has convertible cells and did not use the "
+                    "Newton-Raphson formulation, so the matrix leaves out how "
+                    "their transmissivity follows the head and the "
+                    "sensitivities are approximate. Running the flow model "
+                    "under Newton-Raphson makes them exact."
+                )
             has_sto = False
             if has_sto_iconvert(self._gwf):
                 has_sto = True

--- a/mf6adj/utils/utils_modflow.py
+++ b/mf6adj/utils/utils_modflow.py
@@ -361,3 +361,29 @@ def auto_flow_reduce(gwf_name, pak_name, gwf) -> int:
         )
     except Exception:
         return 0
+
+
+def convertible_cells(gwf_name, gwf) -> bool:
+    """Return whether any cell converts between confined and unconfined.
+
+    The transmissivity of such a cell follows the head through its saturated
+    thickness, which is the dependence the Newton-Raphson formulation carries
+    into the matrix and the standard formulation does not.
+
+    Parameters
+    ----------
+    gwf_name : str
+        Name of the groundwater-flow model.
+    gwf : modflowapi.ModflowApi
+        MODFLOW 6 groundwater-flow instance.
+
+    Returns
+    -------
+    bool
+        True where at least one cell is convertible.
+    """
+    try:
+        icelltype = get_ptr_from_gwf(gwf_name, "NPF", "ICELLTYPE", gwf)
+    except Exception:
+        return False
+    return bool(np.any(np.asarray(icelltype) != 0))


### PR DESCRIPTION
The adjoint is taken from the matrix MODFLOW assembled. Under the Newton-Raphson formulation that matrix is the Jacobian and the sensitivity is exact; under the standard formulation the derivative of the transmissivity with respect to the head is lagged rather than assembled, and a model with convertible cells leaves the adjoint holding the transmissivity fixed. Nothing in the output distinguished that from an exact answer.

| head in the pumped cell | Newton-Raphson | standard |
| --- | --- | --- |
| 5.46 | 0.000% | 5.9% |
| 2.20 | 0.000% | 10.2% |

The error grows as the cell empties, which is where the conductance follows the head most steeply. A confined model is unaffected. That condition is now reported, along with a test that an exact model is not reported.

The term is deliberately not recovered, and the reasoning is worth recording: it cannot be taken from the Newton-Raphson assembly, because the two formulations do not solve the same discrete equations — Newton-Raphson weights the conductance upstream, and the converged heads of the two runs differ. Recovering it means differentiating the conductance the standard formulation actually used, which is one of three cell-averaging schemes over horizontal, vertical, and vertically staggered connections. Running the flow model under Newton-Raphson is the shorter path, and is what the report recommends.

A chapter of the supplemental technical information now sets out when a sensitivity is exact and when it is not, with the reduced well of #101 as the case where the limitation shows most.

Closes #102.