### PR TITLE
fix(adj): refuse an unsupported package while the input is read

### DIFF
--- a/autotest/test_unsupported.py
+++ b/autotest/test_unsupported.py
@@ -1,0 +1,65 @@
+"""
+Tests for packages the adjoint forms no terms for.
+
+The package types the adjoint handles are a fixed set. A model may carry
+others, and their exchange with the aquifer is in the flow matrix, so the head
+sensitivities account for it. The packages themselves have none, and a measure
+of one has no answer.
+
+Cases:
+  - measure_unsupported : a measure on such a package is refused while the
+                          adjoint file is read, rather than failing later.
+  - measure_supported   : a measure on a package that is handled is accepted.
+  - measure_absent      : a name that is in no package at all is still refused
+                          as missing rather than as unsupported.
+"""
+
+import pathlib as pl
+import sys
+
+import pytest
+
+try:
+    import mf6adj
+except ImportError:
+    sys.path.insert(0, str(pl.Path("../").resolve()))
+    import mf6adj
+
+from mf6adj.utils.utils_modflow import (
+    SUPPORTED_PACKAGE_TYPES,
+    UNSUPPORTED_STRESS_TYPES,
+)
+from mf6adj.utils.utils_pm_read import validate_pm_type
+
+# a model carrying a handled package and an unhandled one
+PACKAGE_DICT = {
+    "dis6": ["dis"],
+    "npf6": ["npf"],
+    "ghb6": ["ghb-1"],
+    "uzf6": ["uzf-1"],
+    "maw6": ["maw-1"],
+}
+
+
+@pytest.mark.parametrize("pm_type", ["uzf-1", "maw-1"])
+def test_measure_unsupported(pm_type):
+    """A measure on a package the adjoint does not form terms for is refused."""
+    with pytest.raises(Exception, match="does not form terms for"):
+        validate_pm_type(pm_type, PACKAGE_DICT)
+
+
+@pytest.mark.parametrize("pm_type", ["head", "ghb-1"])
+def test_measure_supported(pm_type):
+    """A measure the adjoint can answer is accepted."""
+    validate_pm_type(pm_type, PACKAGE_DICT)
+
+
+def test_measure_absent():
+    """A name in no package at all is refused as missing, not as unsupported."""
+    with pytest.raises(Exception, match="was not found"):
+        validate_pm_type("nowhere-1", PACKAGE_DICT)
+
+
+def test_supported_and_unsupported_are_distinct():
+    """No package type is both formed and not formed."""
+    assert not set(SUPPORTED_PACKAGE_TYPES) & set(UNSUPPORTED_STRESS_TYPES)

--- a/mf6adj/adj.py
+++ b/mf6adj/adj.py
@@ -21,6 +21,8 @@ from .utils.utils import _utils_cd
 from .utils.utils_fileio import _write_group_to_hdf
 from .utils.utils_logger import _LoggerUtil
 from .utils.utils_modflow import (
+    SUPPORTED_PACKAGE_TYPES,
+    UNSUPPORTED_STRESS_TYPES,
     auto_flow_reduce,
     convertible_cells,
     get_auxiliary_multiplier,
@@ -104,6 +106,24 @@ class Mf6Adj:
             self._gwf_name = next(iter(self._gwf_model_dict.keys()))
             self._gwf_namfile = namfile_dict[self._gwf_name]
             self._gwf_package_dict = get_package_names_from_gwfname(self._gwf_namfile)
+            # A package the adjoint forms no terms for still exchanges water
+            # with the aquifer, and that exchange is in the flow matrix, so the
+            # head sensitivities are usable and only the package's own are
+            # missing. Report it here rather than leave it to be noticed in the
+            # output, or not noticed at all.
+            unsupported = sorted(
+                f"{name} ({package_type})"
+                for package_type in UNSUPPORTED_STRESS_TYPES
+                for name in self._gwf_package_dict.get(package_type, [])
+            )
+            if unsupported:
+                self.logger.logger.warning(
+                    "the flow model has packages the adjoint forms no terms "
+                    f"for: {', '.join(unsupported)}. Their exchange with the "
+                    "aquifer is carried by the flow matrix, so the head "
+                    "sensitivities account for it, but those packages have no "
+                    "sensitivities of their own and cannot be measured."
+                )
             if self._gwf_model_dict[self._gwf_name] != "gwf6":
                 raise Exception(
                     f"model is not a gwf6 type: {self._gwf_model_dict[self._gwf_name]}"
@@ -152,17 +172,7 @@ class Mf6Adj:
                 self._shape = (nlay, nrow, ncol)
             self._performance_measures = []
             self._read_adj_file()
-            self._gwf_package_types = [
-                "chd6",
-                "wel6",
-                "ghb6",
-                "riv6",
-                "drn6",
-                "sfr6",
-                "lak6",
-                "rch6",
-                "evt6",
-            ]
+            self._gwf_package_types = list(SUPPORTED_PACKAGE_TYPES)
             self._gwf_boundary_attr_dict = {
                 "chd6": ["head"],
                 "ghb6": ["bhead", "cond"],

--- a/mf6adj/utils/utils_modflow.py
+++ b/mf6adj/utils/utils_modflow.py
@@ -6,6 +6,31 @@ import numpy as np
 PathLike = Union[str, pl.Path]
 
 
+# the package types the adjoint forms terms for
+SUPPORTED_PACKAGE_TYPES = (
+    "chd6",
+    "wel6",
+    "ghb6",
+    "riv6",
+    "drn6",
+    "sfr6",
+    "lak6",
+    "rch6",
+    "evt6",
+)
+
+# packages that exchange water with the aquifer but whose terms are not formed.
+# A model carrying one still has usable head sensitivities, because the
+# exchange is in the flow matrix, but the package itself has none.
+UNSUPPORTED_STRESS_TYPES = (
+    "uzf6",
+    "maw6",
+    "csub6",
+    "api6",
+    "mvr6",
+)
+
+
 def parse_models_block(f) -> tuple[dict[str, str], dict[str, str]]:
     """Parse the `MODELS` block from an `mfsim.nam` file.
 

--- a/mf6adj/utils/utils_pm_read.py
+++ b/mf6adj/utils/utils_pm_read.py
@@ -3,7 +3,7 @@ from typing import Callable, Optional
 
 import numpy as np
 
-from .utils_modflow import get_node
+from .utils_modflow import SUPPORTED_PACKAGE_TYPES, get_node
 
 PathLike = str | pl.Path
 
@@ -309,9 +309,19 @@ def validate_pm_type(
 
     found = False
     ppnames = []
-    for _, pnames in gwf_package_dict.items():
+    for package_type, pnames in gwf_package_dict.items():
         if pm_type in pnames:
             found = True
+            # the package is in the model, but its terms may not be formed, and
+            # a measure of it would otherwise fail much later with no
+            # explanation of why
+            if package_type not in SUPPORTED_PACKAGE_TYPES:
+                raise Exception(
+                    f"`pm_type` {pm_type} is a {package_type} package, which "
+                    "the adjoint does not form terms for, so a measure of it "
+                    "has no sensitivity. The supported package types are "
+                    + f"{', '.join(SUPPORTED_PACKAGE_TYPES)}."
+                )
             break
         ppnames.extend(pnames)
     if not found:


### PR DESCRIPTION
A measure naming a package the adjoint forms no terms for was accepted, because the package dictionary is parsed from the name file without filtering and the package really is in the model. It then failed inside the adjoint solve with

```
KeyError: "Unable to synchronously open object (object 'uzf-1' doesn't exist)"
```

A name that is in no package at all already had a clear message, so the confusing failure was reserved for the user who did everything right and asked for something not supported. It is now refused while the adjoint file is read, before any forward solve, naming the package type and the supported ones.

A model that merely carries such a package is reported rather than refused: its exchange is in the flow matrix, so the head sensitivities account for it and only the package's own are missing. That is the distinction #103 draws for a model whose matrix is not the derivative of its equations.

Verified against a real UZF model, which previously ran to completion with no `uzf-1` entry in the composite and no indication one was missing.

Refs #104, which also covers supporting UZF itself.