### PR TITLE
refactor(adj): locate the adjoint matrix with the solution's sparsity

### DIFF
--- a/autotest/test_solution_matrix.py
+++ b/autotest/test_solution_matrix.py
@@ -23,6 +23,13 @@ Cases:
                                                  beyond the flow grid's is
                                                  refused rather than solved
                                                  short of equations.
+  - test_missing_equations_are_refused         : a solution carrying fewer
+                                                 equations than the flow grid
+                                                 is refused as a sparsity that
+                                                 does not belong to the grid.
+  - test_mismatched_arrays_are_refused         : arrays that do not describe one
+                                                 matrix are refused where the
+                                                 matrix is assembled.
 """
 
 import pathlib as pl
@@ -184,16 +191,8 @@ def test_forward_file_carries_solution_ia_ja(function_tmpdir):
         assert np.array_equal(info["sln_ja"][:], info["ja"][:])
 
 
-def test_extra_equations_are_refused(function_tmpdir):
-    """A solution with more equations than the flow grid has is refused.
-
-    Mf6Adj rejects such a model as it reads it, so the forward file of a
-    supported model is given one more equation than the grid has to reach the
-    adjoint's own guard. This is the tripwire for the day a package that adds
-    equations is read: the adjoint has to form their terms, not solve without
-    them.
-    """
-    ws = _build_model(function_tmpdir / "m", maw=False)
+def _forward_run(ws):
+    """Run the forward model of a supported model and keep the adjoint open."""
     k, i, j = WELL_CELL
     with open(ws / "pm.dat", "w") as f:
         f.write("begin performance_measure obs\n")
@@ -204,13 +203,83 @@ def test_extra_equations_are_refused(function_tmpdir):
     )
     adj.solve_forward_model(hdf5_name="fwd.hd5")
     adj.finalize()
+    return adj
 
-    shutil.copy(ws / "fwd.hd5", ws / "extra.hd5")
-    with h5py.File(ws / "extra.hd5", "r+") as hf:
+
+def _with_row_count(ws, name, delta):
+    """Copy the forward file, giving its solution sparsity delta more rows."""
+    shutil.copy(ws / "fwd.hd5", ws / name)
+    with h5py.File(ws / name, "r+") as hf:
         sln_ia = hf["gwf_info"]["sln_ia"][:]
         del hf["gwf_info"]["sln_ia"]
-        hf["gwf_info"]["sln_ia"] = np.append(sln_ia, sln_ia[-1])
+        if delta > 0:
+            sln_ia = np.append(sln_ia, [sln_ia[-1]] * delta)
+        else:
+            sln_ia = sln_ia[:delta]
+        hf["gwf_info"]["sln_ia"] = sln_ia
+    return name
 
-    adj._hdf5_name = "extra.hd5"
+
+def test_extra_equations_are_refused(function_tmpdir):
+    """A solution with more equations than the flow grid has is refused.
+
+    Mf6Adj rejects such a model as it reads it, so the forward file of a
+    supported model is given one more equation than the grid has to reach the
+    adjoint's own guard. This is the tripwire for the day a package that adds
+    equations is read: the adjoint has to form their terms, not solve without
+    them.
+    """
+    ws = _build_model(function_tmpdir / "m", maw=False)
+    adj = _forward_run(ws)
+
+    adj._hdf5_name = _with_row_count(ws, "extra.hd5", 1)
     with pytest.raises(Exception, match="equations beyond"):
         adj.solve_adjoint()
+
+
+def test_missing_equations_are_refused(function_tmpdir):
+    """A solution with fewer equations than the flow grid is refused.
+
+    The two conditions are not the same fault. A solution larger than the grid
+    is a package that added equations, which is a model the adjoint may one day
+    carry; a solution smaller than it is a sparsity that never belonged to the
+    grid, and reporting the second as the first would send a reader looking for
+    a package that is not there.
+    """
+    ws = _build_model(function_tmpdir / "m", maw=False)
+    adj = _forward_run(ws)
+
+    adj._hdf5_name = _with_row_count(ws, "short.hd5", -1)
+    with pytest.raises(Exception, match="fewer than"):
+        adj.solve_adjoint()
+
+
+@pytest.mark.parametrize(
+    "case,message",
+    [
+        ("empty", "describes no rows"),
+        ("offset", "rather than 0"),
+        ("short_ja", "do not describe the same matrix"),
+        ("short_amat", "fewer than"),
+        ("out_of_range", "outside"),
+    ],
+)
+def test_mismatched_arrays_are_refused(case, message):
+    """Arrays that do not describe one matrix are refused where it is assembled."""
+    ia = np.array([0, 2, 4], dtype=int)
+    ja = np.array([0, 1, 0, 1], dtype=int)
+    amat = np.array([4.0, -1.0, -1.0, 4.0])
+
+    if case == "empty":
+        ia = np.array([0], dtype=int)
+    elif case == "offset":
+        ia = ia + 1
+    elif case == "short_ja":
+        ja = ja[:-1]
+    elif case == "short_amat":
+        amat = amat[:-1]
+    elif case == "out_of_range":
+        ja = np.array([0, 1, 0, 2], dtype=int)
+
+    with pytest.raises(Exception, match=message):
+        assemble_matrix(amat, ia, ja)

--- a/autotest/test_solution_matrix.py
+++ b/autotest/test_solution_matrix.py
@@ -1,0 +1,216 @@
+"""
+Tests for the sparsity that locates the entries of the assembled matrix.
+
+The adjoint is taken from the matrix MODFLOW assembled, so the row pointer and
+column index that locate its entries have to be the solution's. They match the
+groundwater flow grid's until a package adds its own equations, which puts a
+column inside the row of every cell that package connects to.
+
+Cases:
+  - test_assembled_matrix_reproduces_equations : the assembled matrix and the
+                                                 solution vector satisfy the
+                                                 equations MODFLOW solved, with
+                                                 and without a package that adds
+                                                 equations.
+  - test_grid_connectivity_misplaces_entries   : the grid connectivity does not
+                                                 locate those entries once maw6
+                                                 adds its own.
+  - test_forward_file_carries_solution_ia_ja   : the forward solution file
+                                                 carries the solution sparsity,
+                                                 and it matches the grid's for a
+                                                 model the adjoint supports.
+  - test_extra_equations_are_refused           : a solution carrying equations
+                                                 beyond the flow grid's is
+                                                 refused rather than solved
+                                                 short of equations.
+"""
+
+import pathlib as pl
+import shutil
+import sys
+
+import flopy
+import h5py
+import modflowapi
+import numpy as np
+import pytest
+
+try:
+    import mf6adj
+except ImportError:
+    sys.path.insert(0, str(pl.Path("../").resolve()))
+    import mf6adj
+
+from mf6adj.utils.utils_modflow import assemble_matrix
+
+mf6_bin, lib_name = mf6adj.get_conda_mf6_paths()
+
+NAME = "slnmat"
+NLAY, NROW, NCOL = 3, 5, 5
+BOTM = [-10.0, -100.0, -1000.0]
+WELL_CELL = (1, 2, 2)
+
+
+def _build_model(ws, maw):
+    """A small unconfined model, optionally pumped through a multi-aquifer well."""
+    ws = pl.Path(ws)
+    if ws.exists():
+        shutil.rmtree(ws)
+    ws.mkdir(parents=True)
+    sim = flopy.mf6.MFSimulation(sim_name=NAME, sim_ws=str(ws), exe_name=mf6_bin)
+    flopy.mf6.ModflowTdis(sim, nper=1, perioddata=[(1.0, 1, 1.0)])
+    flopy.mf6.ModflowIms(sim, complexity="complex", outer_dvclose=1e-9)
+    gwf = flopy.mf6.ModflowGwf(
+        sim, modelname=NAME, newtonoptions="NEWTON", save_flows=True
+    )
+    flopy.mf6.ModflowGwfdis(
+        gwf,
+        nlay=NLAY,
+        nrow=NROW,
+        ncol=NCOL,
+        delr=10.0,
+        delc=10.0,
+        top=0.0,
+        botm=BOTM,
+    )
+    flopy.mf6.ModflowGwfic(gwf, strt=0.0)
+    flopy.mf6.ModflowGwfnpf(gwf, icelltype=1, k=1.0, k33=1.0)
+    flopy.mf6.ModflowGwfsto(gwf, iconvert=1, ss=1e-5, sy=0.1, transient={0: True})
+    flopy.mf6.ModflowGwfghb(
+        gwf,
+        stress_period_data=[[(0, i, 0), 0.0, 100.0] for i in range(NROW)],
+        pname="ghb-1",
+    )
+    if maw:
+        # a well screened across every layer, so it takes a column in three
+        # rows of the solution rather than in one
+        flopy.mf6.ModflowGwfmaw(
+            gwf,
+            nmawwells=1,
+            packagedata=[[0, 1.0, BOTM[-1], 0.0, "THIEM", NLAY]],
+            connectiondata=[
+                [0, k, (k, 2, 2), -999, -999, -999.0, -999.0] for k in range(NLAY)
+            ],
+            perioddata={0: [[0, "RATE", -100.0]]},
+            pname="maw-1",
+        )
+    else:
+        flopy.mf6.ModflowGwfwel(
+            gwf, stress_period_data=[[WELL_CELL, -100.0]], pname="wel-1"
+        )
+    flopy.mf6.ModflowGwfoc(
+        gwf, head_filerecord=f"{NAME}.hds", saverecord=[("HEAD", "ALL")]
+    )
+    sim.write_simulation(silent=True)
+    return ws
+
+
+def _solution_arrays(ws):
+    """Return the assembled matrix, its two sparsities, and the solved system.
+
+    The values are taken after one time step, where the matrix MODFLOW last
+    assembled and the heads it converged on satisfy the same equations.
+    """
+    mf6 = modflowapi.ModflowApi(lib_name, working_directory=str(ws))
+    mf6.initialize()
+    mf6.update()
+
+    def value(name, *components):
+        return np.asarray(mf6.get_value(mf6.get_var_address(name, *components)))
+
+    arrays = {
+        "amat": value("AMAT", "SLN_1"),
+        "x": value("X", "SLN_1"),
+        "rhs": value("RHS", "SLN_1"),
+        "sln_ia": value("IA", "SLN_1") - 1,
+        "sln_ja": value("JA", "SLN_1") - 1,
+        "grid_ia": value("IA", NAME.upper(), "CON") - 1,
+        "grid_ja": value("JA", NAME.upper(), "CON") - 1,
+    }
+    mf6.finalize()
+    return arrays
+
+
+def _residual(arrays, ia, ja):
+    """Return the largest residual of the equations, against their own scale."""
+    nrow = len(ia) - 1
+    amat = assemble_matrix(arrays["amat"], ia, ja)
+    residual = amat @ arrays["x"][:nrow] - arrays["rhs"][:nrow]
+    return np.abs(residual).max() / np.abs(arrays["rhs"][:nrow]).max()
+
+
+@pytest.mark.parametrize("maw", [False, True], ids=["wel", "maw"])
+def test_assembled_matrix_reproduces_equations(function_tmpdir, maw):
+    """The solution sparsity locates the entries of the matrix MODFLOW assembled."""
+    arrays = _solution_arrays(_build_model(function_tmpdir / "m", maw))
+
+    nnodes = len(arrays["grid_ia"]) - 1
+    nsolution = len(arrays["sln_ia"]) - 1
+    assert nsolution == nnodes + (1 if maw else 0), (
+        "maw6 adds one equation per well to the solution"
+    )
+
+    assert _residual(arrays, arrays["sln_ia"], arrays["sln_ja"]) < 1.0e-4
+
+
+def test_grid_connectivity_misplaces_entries(function_tmpdir):
+    """The grid connectivity no longer locates those entries once maw6 adds its own."""
+    arrays = _solution_arrays(_build_model(function_tmpdir / "m", maw=True))
+
+    # the well's column is inside the row of each cell it connects to, so the
+    # grid connectivity, which does not count it, shifts every entry after the
+    # first of those rows
+    assert _residual(arrays, arrays["grid_ia"], arrays["grid_ja"]) > 1.0
+
+
+def test_forward_file_carries_solution_ia_ja(function_tmpdir):
+    """A supported model's two sparsities agree, and the forward file carries both."""
+    ws = _build_model(function_tmpdir / "m", maw=False)
+    k, i, j = WELL_CELL
+    with open(ws / "pm.dat", "w") as f:
+        f.write("begin performance_measure obs\n")
+        f.write(f"  1 1 {k + 1} {i + 1} {j + 1} head direct 1.0 -1.0e+30\n")
+        f.write("end performance_measure\n\n")
+    adj = mf6adj.Mf6Adj(
+        "pm.dat", lib_name, logging_level="WARNING", working_directory=str(ws)
+    )
+    adj.solve_forward_model(hdf5_name="fwd.hd5")
+    adj.finalize()
+
+    with h5py.File(ws / "fwd.hd5", "r") as hf:
+        info = hf["gwf_info"]
+        assert "sln_ia" in info and "sln_ja" in info
+        assert np.array_equal(info["sln_ia"][:], info["ia"][:])
+        assert np.array_equal(info["sln_ja"][:], info["ja"][:])
+
+
+def test_extra_equations_are_refused(function_tmpdir):
+    """A solution with more equations than the flow grid has is refused.
+
+    Mf6Adj rejects such a model as it reads it, so the forward file of a
+    supported model is given one more equation than the grid has to reach the
+    adjoint's own guard. This is the tripwire for the day a package that adds
+    equations is read: the adjoint has to form their terms, not solve without
+    them.
+    """
+    ws = _build_model(function_tmpdir / "m", maw=False)
+    k, i, j = WELL_CELL
+    with open(ws / "pm.dat", "w") as f:
+        f.write("begin performance_measure obs\n")
+        f.write(f"  1 1 {k + 1} {i + 1} {j + 1} head direct 1.0 -1.0e+30\n")
+        f.write("end performance_measure\n\n")
+    adj = mf6adj.Mf6Adj(
+        "pm.dat", lib_name, logging_level="WARNING", working_directory=str(ws)
+    )
+    adj.solve_forward_model(hdf5_name="fwd.hd5")
+    adj.finalize()
+
+    shutil.copy(ws / "fwd.hd5", ws / "extra.hd5")
+    with h5py.File(ws / "extra.hd5", "r+") as hf:
+        sln_ia = hf["gwf_info"]["sln_ia"][:]
+        del hf["gwf_info"]["sln_ia"]
+        hf["gwf_info"]["sln_ia"] = np.append(sln_ia, sln_ia[-1])
+
+    adj._hdf5_name = "extra.hd5"
+    with pytest.raises(Exception, match="equations beyond"):
+        adj.solve_adjoint()

--- a/mf6adj/adj.py
+++ b/mf6adj/adj.py
@@ -432,6 +432,15 @@ class Mf6Adj:
         idomain = get_ptr_from_gwf(gwf_name, "DIS", "IDOMAIN", gwf)
         data_dict["idomain"] = idomain
 
+        # The adjoint is taken from the matrix MODFLOW assembled, so the
+        # sparsity that locates its entries is the solution's rather than the
+        # grid's. The two agree until a package adds its own equations, which
+        # puts a column inside the row of every cell it connects to.
+        sln_ia = gwf.get_value(gwf.get_var_address("IA", "SLN_1")) - 1
+        data_dict["sln_ia"] = sln_ia
+        sln_ja = gwf.get_value(gwf.get_var_address("JA", "SLN_1")) - 1
+        data_dict["sln_ja"] = sln_ja
+
         if self.is_structured:
             nlay = get_ptr_from_gwf(gwf_name, dis_pak, "NLAY", gwf)
             data_dict["nlay"] = nlay

--- a/mf6adj/pm.py
+++ b/mf6adj/pm.py
@@ -662,12 +662,21 @@ class PerfMeas:
         # Mf6Adj rejects such a model as it reads it; this is the same
         # condition seen from the forward solution file.
         nsln = len(sln_ia) - 1
-        if nsln != nnode:
+        if nsln > nnode:
             raise Exception(
                 "the matrix MODFLOW assembled has "
                 + f"{nsln - nnode} equations beyond the {nnode} of the flow "
                 + "grid, which a package such as maw6 added to the solution. "
                 + "The adjoint does not form the terms for those equations yet."
+            )
+        if nsln < nnode:
+            # the solution holds one equation per cell and one for every
+            # equation a package adds, so it is never short of the grid
+            raise Exception(
+                f"the matrix MODFLOW assembled has {nsln} equations, fewer "
+                + f"than the {nnode} of the flow grid, so the sparsity in "
+                + f"forward solution file '{hdf5_forward_solution_fname}' does "
+                + "not belong to that grid."
             )
         self._lake = LakeCoupling(logger=self.logger.logger)
         self._sfr = SfrCoupling(logger=self.logger.logger)

--- a/mf6adj/pm.py
+++ b/mf6adj/pm.py
@@ -28,6 +28,7 @@ from .utils.utils import SolverCallback
 from .utils.utils_fileio import _write_group_to_hdf
 from .utils.utils_logger import _LoggerUtil
 from .utils.utils_modflow import (
+    assemble_matrix,
     get_mf6_bound_dict,
 )
 
@@ -608,6 +609,14 @@ class PerfMeas:
 
         ia = hdf["gwf_info"]["ia"][:]
         ja = hdf["gwf_info"]["ja"][:]
+        # the sparsity that locates the entries of the assembled matrix;
+        # written by solve_forward_model, and an older forward file has only
+        # the grid's, which is the same until a package adds its own equations
+        if "sln_ia" in hdf["gwf_info"]:
+            sln_ia = hdf["gwf_info"]["sln_ia"][:]
+            sln_ja = hdf["gwf_info"]["sln_ja"][:]
+        else:
+            sln_ia, sln_ja = ia, ja
         ihc = hdf["gwf_info"]["ihc"][:]
         jas = hdf["gwf_info"]["jas"][:]
         cl1 = hdf["gwf_info"]["cl1"][:]
@@ -646,6 +655,20 @@ class PerfMeas:
         # the lake water balance. nnodes is a one-element array, so keep a
         # scalar for slicing the bordered solution.
         nnode = int(np.asarray(nnodes).ravel()[0])
+
+        # A package that adds its own equations puts them after the aquifer
+        # rows of the solution. Nothing forms their side of the adjoint yet,
+        # so refuse rather than solve a system that is short of equations.
+        # Mf6Adj rejects such a model as it reads it; this is the same
+        # condition seen from the forward solution file.
+        nsln = len(sln_ia) - 1
+        if nsln != nnode:
+            raise Exception(
+                "the matrix MODFLOW assembled has "
+                + f"{nsln - nnode} equations beyond the {nnode} of the flow "
+                + "grid, which a package such as maw6 added to the solution. "
+                + "The adjoint does not form the terms for those equations yet."
+            )
         self._lake = LakeCoupling(logger=self.logger.logger)
         self._sfr = SfrCoupling(logger=self.logger.logger)
 
@@ -731,10 +754,7 @@ class PerfMeas:
             amat = hdf[sol_key]["amat"][:]
             head = hdf[sol_key]["head"][:]
             residual = hdf[sol_key]["residual"][:]
-            amat = sparse.csr_matrix(
-                (amat.copy()[: ja.shape[0]], ja.copy(), ia.copy()),
-                shape=(len(ia) - 1, len(ia) - 1),
-            )
+            amat = assemble_matrix(amat, sln_ia, sln_ja)
             amat = amat.transpose().tocsr()
 
             # the lake state is per time step: a step with no free lake must

--- a/mf6adj/utils/utils_modflow.py
+++ b/mf6adj/utils/utils_modflow.py
@@ -2,6 +2,7 @@ import pathlib as pl
 from typing import Any, Union
 
 import numpy as np
+import scipy.sparse as sparse
 
 PathLike = Union[str, pl.Path]
 
@@ -177,6 +178,36 @@ def get_package_names_from_gwfname(
                 return parse_packages_block(f)
 
     raise EOFError("EOF when looking for 'packages' block")
+
+
+def assemble_matrix(amat: np.ndarray, ia: np.ndarray, ja: np.ndarray):
+    """Return the assembled matrix as a sparse CSR matrix.
+
+    The adjoint is taken from the matrix MODFLOW assembled, so `ia` and `ja`
+    must be the ones that locate its entries. A package that adds its own
+    equations puts a column inside the row of every cell it connects to, and
+    the grid connectivity no longer counts those entries, so the grid arrays
+    misplace every entry after the first such row.
+
+    Parameters
+    ----------
+    amat : ndarray
+        Coefficients of the assembled matrix.
+    ia : ndarray
+        Zero-based row pointer into `ja`.
+    ja : ndarray
+        Zero-based column of each coefficient.
+
+    Returns
+    -------
+    scipy.sparse.csr_matrix
+        The assembled matrix.
+    """
+    nrow = len(ia) - 1
+    return sparse.csr_matrix(
+        (amat[: ja.shape[0]].copy(), ja.copy(), ia.copy()),
+        shape=(nrow, nrow),
+    )
 
 
 def get_mf6_bound_dict() -> dict[str, dict[int, str]]:

--- a/mf6adj/utils/utils_modflow.py
+++ b/mf6adj/utils/utils_modflow.py
@@ -202,8 +202,41 @@ def assemble_matrix(amat: np.ndarray, ia: np.ndarray, ja: np.ndarray):
     -------
     scipy.sparse.csr_matrix
         The assembled matrix.
+
+    Raises
+    ------
+    Exception
+        If the three arrays do not describe one matrix. A forward solution file
+        written by another run, or one written before the sparsity it carries
+        was the solution's, fails here rather than further on, where a matrix
+        assembled from mismatched arrays has no symptom that names its cause.
     """
     nrow = len(ia) - 1
+    if nrow < 1:
+        raise Exception(
+            f"the row pointer has {len(ia)} entries, which describes no rows"
+        )
+    if ia[0] != 0:
+        raise Exception(
+            f"the row pointer starts at {ia[0]} rather than 0, so it is not "
+            + "the zero-based pointer this expects"
+        )
+    if ia[-1] != ja.shape[0]:
+        raise Exception(
+            f"the row pointer ends at {ia[-1]} and the column index has "
+            + f"{ja.shape[0]} entries, so the two do not describe the same "
+            + "matrix"
+        )
+    if amat.shape[0] < ja.shape[0]:
+        raise Exception(
+            f"the matrix has {amat.shape[0]} coefficients, fewer than the "
+            + f"{ja.shape[0]} entries the column index locates"
+        )
+    if ja.shape[0] > 0 and (ja.min() < 0 or ja.max() >= nrow):
+        raise Exception(
+            f"the column index runs from {ja.min()} to {ja.max()}, outside "
+            + f"the {nrow} rows the row pointer describes"
+        )
     return sparse.csr_matrix(
         (amat[: ja.shape[0]].copy(), ja.copy(), ia.copy()),
         shape=(nrow, nrow),


### PR DESCRIPTION
The adjoint matrix was located with the groundwater flow grid connectivity, which stops matching the matrix MODFLOW assembled as soon as a package adds its own equations to the solution. The forward solution file now carries the solution row pointer and column index, and the matrix is assembled from those. Nothing changes for a supported model, where the two are identical; a solution with equations beyond the flow grid is refused where the matrix is assembled.

Prerequisite for a maw6 performance measure.

Refs #78.