### PR TITLE
feat(maw): measure the exchange between a multi-aquifer well and the aquifer

### DIFF
--- a/autotest/test_ie.py
+++ b/autotest/test_ie.py
@@ -6,7 +6,7 @@ import sys
 from datetime import datetime
 
 import flopy
-import pytest
+import numpy as np
 
 try:
     import mf6adj
@@ -68,7 +68,7 @@ def test_ie_nomaw_1sp():
 
 
 def test_ie_1sp():
-    """The same model with maw6 is rejected: MAW adds equations to the matrix."""
+    """The same model with maw6, whose wells add equations to the matrix."""
     org_d = pl.Path("ie_1sp")
     new_d = "ie_1sp_test"
     new_dir = pl.Path(new_d)
@@ -78,20 +78,32 @@ def test_ie_1sp():
         shutil.rmtree(new_dir)
     shutil.copytree(org_d, new_dir)
 
-    # the coupling check runs before the adjoint file is read, so the file only
-    # has to exist
-    with open(adj_file, "w") as f:
-        f.write("begin performance_measure single\n")
-        f.write(f"1 1 {32} {1808} head direct 1.0 -1.0e+30\n")
-        f.write("end performance_measure\n")
+    flopy.run_model(exe_name=mf6_bin, namefile=None, model_ws=new_dir)
 
-    with pytest.raises(Exception, match="solution matrix"):
-        mf6adj.Mf6Adj(
-            adj_file.name,
-            lib_name,
-            logging_level="INFO",
-            working_directory=new_dir,
-        )
+    sim = flopy.mf6.MFSimulation.load(sim_ws=new_dir, load_only=["dis"])
+    nstp = sim.tdis.perioddata.array[0][1]
+
+    with open(adj_file, "w") as f:
+        f.write("begin performance_measure single_all_times\n")
+        for kper in range(sim.tdis.nper.data):
+            f.write(f"{kper + 1} {nstp} {32} {1808} head direct 1.0 -1.0e+30\n")
+        f.write("end performance_measure\n\n")
+
+    adj = mf6adj.Mf6Adj(
+        adj_file.name,
+        lib_name,
+        logging_level="INFO",
+        working_directory=new_dir,
+    )
+    adj.solve_forward_model()
+    df = adj.solve_adjoint(
+        linear_solver="bicgstab",
+        linear_solver_kwargs={"maxiter": 500, "atol": 1e-5},
+        use_precon=True,
+    )
+    adj.finalize()
+
+    assert np.isfinite(df["single_all_times"]["k11"].values).all()
 
 
 if __name__ == "__main__":

--- a/autotest/test_lak.py
+++ b/autotest/test_lak.py
@@ -11,7 +11,7 @@ Cases:
                       stage and conductance.
   - duplicate_bnd   : two boundaries in one cell accumulate rather than
                       overwrite.
-  - maw_rejected    : a model with maw6 is rejected because it adds equations
+  - maw_accepted    : a model with both a lake and a multi-aquifer well
                       to the solution matrix.
   - lak_total_deriv : a free lake stage reproduces a finite-difference total
                       derivative.
@@ -310,20 +310,23 @@ def test_duplicate_boundary_accumulates(function_tmpdir):
     ), "the two boundaries in the shared cell did not both contribute"
 
 
-def test_maw_rejected(function_tmpdir):
-    """maw6 adds equations to the solution matrix and must be rejected."""
+def test_maw_accepted(function_tmpdir):
+    """A lake and a multi-aquifer well in one model are both carried."""
     ws = function_tmpdir / "maw"
     sim, _ = _build_model(ws, boundary="lak", maw=True)
     sim.run_simulation(silent=True)
 
     adj_file = _write_adj(ws, [(1, 4, 4)], "head", name="h")
-    with pytest.raises(Exception, match="solution matrix"):
-        mf6adj.Mf6Adj(
-            adj_file.name,
-            str(lib_name),
-            logging_level="WARNING",
-            working_directory=str(ws),
-        )
+    adj = mf6adj.Mf6Adj(
+        adj_file.name,
+        str(lib_name),
+        logging_level="WARNING",
+        working_directory=str(ws),
+    )
+    adj.solve_forward_model()
+    df = adj.solve_adjoint()
+    adj.finalize()
+    assert np.isfinite(df["h"]["k11"].values).all()
 
 
 def test_lak_total_derivative(function_tmpdir):

--- a/autotest/test_maw.py
+++ b/autotest/test_maw.py
@@ -26,6 +26,13 @@ Cases:
   - test_inactive_well           : an inactive well exchanges nothing and
                                    leaves the sensitivities alone.
   - test_two_packages            : two well packages keep their own rows.
+  - test_rate_sensitivity        : the sensitivity of the measure to the rate a
+                                   well is given matches a finite-difference
+                                   derivative.
+  - test_conductance_sensitivity : the same for the conductance of each
+                                   connection, including one whose screen is
+                                   partly saturated and one whose well head is
+                                   held.
   - test_measure_on_maw_accepted : a measure naming a maw6 package is accepted.
 """
 
@@ -53,6 +60,9 @@ MAW_CELL = (3, 3)
 WELL_CELL = (0, 5, 5)
 WELL_RATE = -50.0
 GHB_HEAD = -4.0
+# conductances used where a test perturbs them, which needs them given rather
+# than computed from the well radius
+CONDUCTANCE = [40.0, 500.0, 1400.0]
 
 
 def _build_model(
@@ -63,6 +73,7 @@ def _build_model(
     maw_head=-6.0,
     nstp=1,
     second_package=False,
+    conductance=None,
 ):
     """An unconfined model pumped through a multi-aquifer well.
 
@@ -113,13 +124,32 @@ def _build_model(
     else:
         period = [[0, "RATE", maw_rate]]
     i, j = MAW_CELL
+    if conductance is None:
+        equation = "THIEM"
+        connections = [
+            [0, k, (k, i, j), -999, -999, -999.0, -999.0] for k in range(NLAY)
+        ]
+    else:
+        # a specified conductance is a value the model is given, so a test can
+        # perturb it; THIEM computes one from the well radius instead
+        equation = "SPECIFIED"
+        connections = [
+            [
+                0,
+                k,
+                (k, i, j),
+                TOP if k == 0 else BOTM[k - 1],
+                BOTM[k],
+                conductance[k],
+                -999.0,
+            ]
+            for k in range(NLAY)
+        ]
     flopy.mf6.ModflowGwfmaw(
         gwf,
         nmawwells=1,
-        packagedata=[[0, 0.5, BOTM[-1], TOP, "THIEM", NLAY]],
-        connectiondata=[
-            [0, k, (k, i, j), -999, -999, -999.0, -999.0] for k in range(NLAY)
-        ],
+        packagedata=[[0, 0.5, BOTM[-1], TOP, equation, NLAY]],
+        connectiondata=connections,
         perioddata={0: period},
         pname="maw-1",
         save_flows=True,
@@ -174,7 +204,15 @@ def _solve_adjoint(ws, entry, nstp=1, name="pm"):
     adj.solve_adjoint()
     adj.finalize()
     with h5py.File(ws / f"adjoint_solution_{name}.hd5", "r") as hf:
-        return {key: hf["composite"][key][:] for key in hf["composite"]}
+        composite = {}
+        for key, item in hf["composite"].items():
+            # a package whose terms are given per well, or per connection, is
+            # written as its own group rather than mapped onto the grid
+            if isinstance(item, h5py.Group):
+                composite[key] = {k: v[:] for k, v in item.items()}
+            else:
+                composite[key] = item[:]
+        return composite
 
 
 def _measure_entry(kind):
@@ -304,3 +342,52 @@ def test_measure_on_maw_accepted():
     from mf6adj.utils.utils_pm_read import validate_pm_type
 
     validate_pm_type("maw-1", {"dis6": ["dis"], "maw6": ["maw-1"]})
+
+
+@pytest.mark.parametrize("nstp", [1, 4])
+def test_rate_sensitivity(function_tmpdir, nstp):
+    """The sensitivity to the rate a well is given matches a finite difference."""
+    rate = -300.0
+    dr = -5.0
+
+    base = _build_model(function_tmpdir / "base", maw_rate=rate, nstp=nstp)
+    plus = _build_model(function_tmpdir / "plus", maw_rate=rate + dr, nstp=nstp)
+    minus = _build_model(function_tmpdir / "minus", maw_rate=rate - dr, nstp=nstp)
+    finite_difference = (_connection_flux(plus) - _connection_flux(minus)) / (2.0 * dr)
+
+    composite = _solve_adjoint(base, _measure_entry("maw-1"), nstp=nstp)
+    # the rate is given for the whole stress period, so it perturbs every time
+    # step, and the composite has summed the steps already
+    assert composite["maw-1"]["rate"].sum() == pytest.approx(
+        finite_difference, rel=1.0e-3
+    )
+
+
+@pytest.mark.parametrize("status", ["ACTIVE", "CONSTANT"])
+def test_conductance_sensitivity(function_tmpdir, status):
+    """The sensitivity to each connection conductance matches a finite difference."""
+    composite = _solve_adjoint(
+        _build_model(function_tmpdir / "base", status=status, conductance=CONDUCTANCE),
+        _measure_entry("maw-1"),
+    )
+
+    for iconn in range(NLAY):
+        dc = 0.01 * CONDUCTANCE[iconn]
+        plus, minus = list(CONDUCTANCE), list(CONDUCTANCE)
+        plus[iconn] += dc
+        minus[iconn] -= dc
+        finite_difference = (
+            _connection_flux(
+                _build_model(
+                    function_tmpdir / f"p{iconn}", status=status, conductance=plus
+                )
+            )
+            - _connection_flux(
+                _build_model(
+                    function_tmpdir / f"m{iconn}", status=status, conductance=minus
+                )
+            )
+        ) / (2.0 * dc)
+        assert composite["maw-1"]["cond"][iconn] == pytest.approx(
+            finite_difference, rel=1.0e-3
+        ), f"connection {iconn}"

--- a/autotest/test_maw.py
+++ b/autotest/test_maw.py
@@ -29,6 +29,10 @@ Cases:
   - test_rate_sensitivity        : the sensitivity of the measure to the rate a
                                    well is given matches a finite-difference
                                    derivative.
+  - test_head_sensitivity        : the same for the head a well is held at.
+  - test_terms_match_the_status  : a well carries a sensitivity to the rate it
+                                   is given or to the head it is held at, never
+                                   to both, and an inactive well to neither.
   - test_conductance_sensitivity : the same for the conductance of each
                                    connection, including one whose screen is
                                    partly saturated and one whose well head is
@@ -361,6 +365,49 @@ def test_rate_sensitivity(function_tmpdir, nstp):
     assert composite["maw-1"]["rate"].sum() == pytest.approx(
         finite_difference, rel=1.0e-3
     )
+
+
+@pytest.mark.parametrize("nstp", [1, 4])
+def test_head_sensitivity(function_tmpdir, nstp):
+    """The sensitivity to the head a well is held at matches a finite difference."""
+    head = -6.0
+    dh = 0.02
+
+    kwargs = {"status": "CONSTANT", "nstp": nstp}
+    base = _build_model(function_tmpdir / "base", maw_head=head, **kwargs)
+    plus = _build_model(function_tmpdir / "plus", maw_head=head + dh, **kwargs)
+    minus = _build_model(function_tmpdir / "minus", maw_head=head - dh, **kwargs)
+    finite_difference = (_connection_flux(plus) - _connection_flux(minus)) / (2.0 * dh)
+
+    composite = _solve_adjoint(base, _measure_entry("maw-1"), nstp=nstp)
+    # the head is given for the whole stress period, so it perturbs every step
+    assert composite["maw-1"]["head"].sum() == pytest.approx(
+        finite_difference, rel=1.0e-3
+    )
+
+
+@pytest.mark.parametrize(
+    "status,expected",
+    [("ACTIVE", "rate"), ("CONSTANT", "head"), ("INACTIVE", None)],
+)
+def test_terms_match_the_status(function_tmpdir, status, expected):
+    """A well carries a sensitivity to the term its equation actually holds.
+
+    A well solving its head against a rate has no head to be sensitive to, and
+    one holding a head has no rate; reporting the adjoint state of the equation
+    as a rate sensitivity in either case would give the second a number that is
+    not one.
+    """
+    composite = _solve_adjoint(
+        _build_model(function_tmpdir / "base", status=status), _measure_entry("maw-1")
+    )
+    maw = composite["maw-1"]
+
+    for term in ("rate", "head"):
+        if term == expected:
+            assert maw[term][0] != 0.0, f"{status} should have a {term} sensitivity"
+        else:
+            assert maw[term][0] == 0.0, f"{status} should have no {term} sensitivity"
 
 
 @pytest.mark.parametrize("status", ["ACTIVE", "CONSTANT"])

--- a/autotest/test_maw.py
+++ b/autotest/test_maw.py
@@ -1,0 +1,306 @@
+"""
+Tests for the multi-aquifer well terms of the adjoint solution.
+
+A multi-aquifer well head is a dependent variable, and MODFLOW 6 solves it with
+the flow equations rather than outside them, so the well's own equation is
+already a row of the matrix the adjoint is taken from. What the adjoint forms
+is the right-hand side of that row: the derivative of a performance measure
+with respect to the well head, and the storage the well carries from one time
+step to the next.
+
+The exchange between a well and a cell follows the head in the cell twice over,
+through the head difference and through the saturated fraction of the screen
+that sets the conductance. A measure of that exchange has to carry both or it
+is wrong by the second, which is the larger error where the screen is only
+partly saturated.
+
+Cases:
+  - test_flux_measure            : a measure of the exchange at one cell
+                                   matches a finite-difference derivative, for
+                                   a well whose head is solved and one whose
+                                   head is held, over one time step and four.
+  - test_conductance_derivative  : dropping the conductance derivative moves
+                                   the answer, so the test above is testing it.
+  - test_head_measure            : a head measure in a model with a well
+                                   matches a finite-difference derivative.
+  - test_inactive_well           : an inactive well exchanges nothing and
+                                   leaves the sensitivities alone.
+  - test_two_packages            : two well packages keep their own rows.
+  - test_measure_on_maw_accepted : a measure naming a maw6 package is accepted.
+"""
+
+import pathlib as pl
+import shutil
+import sys
+
+import flopy
+import h5py
+import numpy as np
+import pytest
+
+try:
+    import mf6adj
+except ImportError:
+    sys.path.insert(0, str(pl.Path("../").resolve()))
+    import mf6adj
+
+mf6_bin, lib_name = mf6adj.get_conda_mf6_paths()
+
+NAME = "maw"
+NLAY, NROW, NCOL = 3, 7, 7
+TOP, BOTM = 0.0, [-10.0, -60.0, -200.0]
+MAW_CELL = (3, 3)
+WELL_CELL = (0, 5, 5)
+WELL_RATE = -50.0
+GHB_HEAD = -4.0
+
+
+def _build_model(
+    ws,
+    wel_rate=WELL_RATE,
+    maw_rate=-300.0,
+    status="ACTIVE",
+    maw_head=-6.0,
+    nstp=1,
+    second_package=False,
+):
+    """An unconfined model pumped through a multi-aquifer well.
+
+    The screen is only partly saturated in the upper layer, so the conductance
+    of that connection follows the head.
+    """
+    ws = pl.Path(ws)
+    if ws.exists():
+        shutil.rmtree(ws)
+    ws.mkdir(parents=True)
+    sim = flopy.mf6.MFSimulation(sim_name=NAME, sim_ws=str(ws), exe_name=mf6_bin)
+    flopy.mf6.ModflowTdis(sim, nper=1, perioddata=[(60.0, nstp, 1.0)])
+    flopy.mf6.ModflowIms(
+        sim,
+        complexity="complex",
+        outer_dvclose=1e-11,
+        inner_dvclose=1e-12,
+        outer_maximum=500,
+    )
+    gwf = flopy.mf6.ModflowGwf(
+        sim, modelname=NAME, save_flows=True, newtonoptions="NEWTON"
+    )
+    flopy.mf6.ModflowGwfdis(
+        gwf,
+        nlay=NLAY,
+        nrow=NROW,
+        ncol=NCOL,
+        delr=50.0,
+        delc=50.0,
+        top=TOP,
+        botm=BOTM,
+    )
+    flopy.mf6.ModflowGwfic(gwf, strt=GHB_HEAD)
+    flopy.mf6.ModflowGwfnpf(gwf, icelltype=1, k=5.0, k33=0.5)
+    flopy.mf6.ModflowGwfsto(gwf, iconvert=1, ss=1e-5, sy=0.15, transient={0: True})
+    flopy.mf6.ModflowGwfghb(
+        gwf,
+        stress_period_data=[[(0, i, 0), GHB_HEAD, 500.0] for i in range(NROW)],
+        pname="ghb-1",
+    )
+    flopy.mf6.ModflowGwfwel(
+        gwf, stress_period_data=[[WELL_CELL, wel_rate]], pname="wel-1"
+    )
+    if status == "CONSTANT":
+        period = [[0, "STATUS", "CONSTANT"], [0, "WELL_HEAD", maw_head]]
+    elif status == "INACTIVE":
+        period = [[0, "STATUS", "INACTIVE"]]
+    else:
+        period = [[0, "RATE", maw_rate]]
+    i, j = MAW_CELL
+    flopy.mf6.ModflowGwfmaw(
+        gwf,
+        nmawwells=1,
+        packagedata=[[0, 0.5, BOTM[-1], TOP, "THIEM", NLAY]],
+        connectiondata=[
+            [0, k, (k, i, j), -999, -999, -999.0, -999.0] for k in range(NLAY)
+        ],
+        perioddata={0: period},
+        pname="maw-1",
+        save_flows=True,
+    )
+    if second_package:
+        flopy.mf6.ModflowGwfmaw(
+            gwf,
+            nmawwells=1,
+            packagedata=[[0, 0.5, BOTM[-1], TOP, "THIEM", 2]],
+            connectiondata=[
+                [0, k, (k, 1, 1), -999, -999, -999.0, -999.0] for k in range(2)
+            ],
+            perioddata={0: [[0, "RATE", -80.0]]},
+            pname="maw-2",
+            save_flows=True,
+        )
+    flopy.mf6.ModflowGwfoc(
+        gwf,
+        head_filerecord=f"{NAME}.hds",
+        budget_filerecord=f"{NAME}.cbc",
+        saverecord=[("HEAD", "ALL"), ("BUDGET", "ALL")],
+    )
+    sim.write_simulation(silent=True)
+    success, buff = sim.run_simulation(silent=True)
+    assert success, "\n".join(buff[-20:])
+    return ws
+
+
+def _connection_flux(ws, iconn=0):
+    """The exchange between the well and one of the cells it connects to."""
+    cbc = flopy.utils.CellBudgetFile(pl.Path(ws) / f"{NAME}.cbc")
+    record = cbc.get_data(text="MAW", kstpkper=cbc.get_kstpkper()[-1])[0]
+    return float(record["q"][iconn])
+
+
+def _final_head(ws, cell):
+    head = flopy.utils.HeadFile(pl.Path(ws) / f"{NAME}.hds")
+    return float(head.get_data(kstpkper=head.get_kstpkper()[-1])[cell])
+
+
+def _solve_adjoint(ws, entry, nstp=1, name="pm"):
+    """Return the composite sensitivities of one performance measure."""
+    ws = pl.Path(ws)
+    with open(ws / "pm.dat", "w") as f:
+        f.write(f"begin performance_measure {name}\n")
+        f.write(f"  1 {nstp} {entry}\n")
+        f.write("end performance_measure\n\n")
+    adj = mf6adj.Mf6Adj(
+        "pm.dat", lib_name, logging_level="WARNING", working_directory=str(ws)
+    )
+    adj.solve_forward_model(hdf5_name="fwd.hd5")
+    adj.solve_adjoint()
+    adj.finalize()
+    with h5py.File(ws / f"adjoint_solution_{name}.hd5", "r") as hf:
+        return {key: hf["composite"][key][:] for key in hf["composite"]}
+
+
+def _measure_entry(kind):
+    """The performance-measure entry for the upper connection of the well."""
+    i, j = MAW_CELL
+    return f"1 {i + 1} {j + 1} {kind} direct 1.0 -1.0e+30"
+
+
+@pytest.mark.parametrize("status", ["ACTIVE", "CONSTANT"])
+@pytest.mark.parametrize("nstp", [1, 4])
+def test_flux_measure(function_tmpdir, status, nstp):
+    """A measure of the exchange matches a finite-difference derivative."""
+    dq = -1.0  # small enough to stay in the linear range
+
+    kwargs = {"status": status, "nstp": nstp}
+    base = _build_model(function_tmpdir / "base", **kwargs)
+    plus = _build_model(function_tmpdir / "plus", wel_rate=WELL_RATE + dq, **kwargs)
+    minus = _build_model(function_tmpdir / "minus", wel_rate=WELL_RATE - dq, **kwargs)
+    finite_difference = (_connection_flux(plus) - _connection_flux(minus)) / (2.0 * dq)
+
+    # the measure has to respond, or it is testing nothing
+    assert abs(finite_difference) > 1.0e-4
+
+    composite = _solve_adjoint(base, _measure_entry("maw-1"), nstp=nstp)
+    assert composite["wel6_q"][WELL_CELL] == pytest.approx(
+        finite_difference, rel=1.0e-3
+    )
+
+
+def test_conductance_derivative(function_tmpdir):
+    """The exchange follows the head through the conductance, not only the drop.
+
+    The upper connection of the well is only partly saturated, so dropping the
+    derivative of its conductance leaves a sensitivity that is wrong by more
+    than the tolerance the test above holds the adjoint to.
+    """
+    from mf6adj.advanced_packages import MawCoupling
+
+    dq = -1.0
+    base = _build_model(function_tmpdir / "base")
+    plus = _build_model(function_tmpdir / "plus", wel_rate=WELL_RATE + dq)
+    minus = _build_model(function_tmpdir / "minus", wel_rate=WELL_RATE - dq)
+    finite_difference = (_connection_flux(plus) - _connection_flux(minus)) / (2.0 * dq)
+
+    original = MawCoupling.blocks
+
+    def without_conductance_derivative(self, sol_dataset, gwf_package_dict, is_newton):
+        blocks = original(self, sol_dataset, gwf_package_dict, is_newton)
+        for block in blocks:
+            block["dterm"] = np.zeros_like(block["dterm"])
+        return blocks
+
+    MawCoupling.blocks = without_conductance_derivative
+    try:
+        composite = _solve_adjoint(base, _measure_entry("maw-1"))
+    finally:
+        MawCoupling.blocks = original
+
+    dropped = composite["wel6_q"][WELL_CELL]
+    assert abs(dropped - finite_difference) > 0.05 * abs(finite_difference), (
+        "the conductance derivative made no difference, so the model does not "
+        "exercise a partly saturated screen"
+    )
+
+
+def test_head_measure(function_tmpdir):
+    """A head measure in a model with a well matches a finite difference."""
+    dq = -1.0
+    observation = (0, 2, 2)
+
+    base = _build_model(function_tmpdir / "base", nstp=4)
+    plus = _build_model(function_tmpdir / "plus", wel_rate=WELL_RATE + dq, nstp=4)
+    minus = _build_model(function_tmpdir / "minus", wel_rate=WELL_RATE - dq, nstp=4)
+    finite_difference = (
+        _final_head(plus, observation) - _final_head(minus, observation)
+    ) / (2.0 * dq)
+
+    k, i, j = observation
+    entry = f"{k + 1} {i + 1} {j + 1} head direct 1.0 -1.0e+30"
+    composite = _solve_adjoint(base, entry, nstp=4)
+    assert composite["wel6_q"][WELL_CELL] == pytest.approx(
+        finite_difference, rel=1.0e-3
+    )
+
+
+def test_inactive_well(function_tmpdir):
+    """An inactive well exchanges nothing and leaves the sensitivities alone."""
+    observation = (0, 2, 2)
+    k, i, j = observation
+    entry = f"{k + 1} {i + 1} {j + 1} head direct 1.0 -1.0e+30"
+
+    inactive = _solve_adjoint(
+        _build_model(function_tmpdir / "off", status="INACTIVE"), entry, name="off"
+    )
+    # the well's row stays in the matrix, holding the head it is given, so the
+    # answer has to be the one the model gives with no well at all
+    dq = -1.0
+    plus = _build_model(
+        function_tmpdir / "plus", wel_rate=WELL_RATE + dq, status="INACTIVE"
+    )
+    minus = _build_model(
+        function_tmpdir / "minus", wel_rate=WELL_RATE - dq, status="INACTIVE"
+    )
+    finite_difference = (
+        _final_head(plus, observation) - _final_head(minus, observation)
+    ) / (2.0 * dq)
+    assert inactive["wel6_q"][WELL_CELL] == pytest.approx(finite_difference, rel=1.0e-3)
+
+
+def test_two_packages(function_tmpdir):
+    """Two well packages keep their own rows in the solution."""
+    dq = -1.0
+    kwargs = {"second_package": True}
+    base = _build_model(function_tmpdir / "base", **kwargs)
+    plus = _build_model(function_tmpdir / "plus", wel_rate=WELL_RATE + dq, **kwargs)
+    minus = _build_model(function_tmpdir / "minus", wel_rate=WELL_RATE - dq, **kwargs)
+    finite_difference = (_connection_flux(plus) - _connection_flux(minus)) / (2.0 * dq)
+
+    composite = _solve_adjoint(base, _measure_entry("maw-1"))
+    assert composite["wel6_q"][WELL_CELL] == pytest.approx(
+        finite_difference, rel=1.0e-3
+    )
+
+
+def test_measure_on_maw_accepted():
+    """A measure naming a maw6 package is accepted rather than refused."""
+    from mf6adj.utils.utils_pm_read import validate_pm_type
+
+    validate_pm_type("maw-1", {"dis6": ["dis"], "maw6": ["maw-1"]})

--- a/autotest/test_unsupported.py
+++ b/autotest/test_unsupported.py
@@ -37,11 +37,11 @@ PACKAGE_DICT = {
     "npf6": ["npf"],
     "ghb6": ["ghb-1"],
     "uzf6": ["uzf-1"],
-    "maw6": ["maw-1"],
+    "csub6": ["csub-1"],
 }
 
 
-@pytest.mark.parametrize("pm_type", ["uzf-1", "maw-1"])
+@pytest.mark.parametrize("pm_type", ["uzf-1", "csub-1"])
 def test_measure_unsupported(pm_type):
     """A measure on a package the adjoint does not form terms for is refused."""
     with pytest.raises(Exception, match="does not form terms for"):

--- a/autotest/test_xd_box.py
+++ b/autotest/test_xd_box.py
@@ -1582,10 +1582,6 @@ def test_xd_box_drn():
     xd_box_compare(new_d, plot_compare)
     return
 
-@pytest.mark.skip(
-    reason="maw6 adds equations to the solution matrix, which the adjoint "
-    "cannot rebuild from the grid connectivity (INTERA-Inc/mf6adj#78)"
-)
 def test_xd_box_maw():
     """
     permutations:

--- a/docs/SuppInfo/Makefile
+++ b/docs/SuppInfo/Makefile
@@ -11,7 +11,7 @@ LATEX = pdflatex -interaction=nonstopmode -halt-on-error
 all: $(DOC).pdf
 
 $(DOC).pdf: $(DOC).tex body.tex introduction.tex instantaneous.tex \
-            storage.tex lake.tex sfr.tex references.bib \
+            storage.tex lake.tex sfr.tex maw.tex references.bib \
             Figures/sfr-capture.pdf Figures/lake-capture.pdf
 	$(LATEX) $(DOC)
 	-bibtex $(DOC)

--- a/docs/SuppInfo/body.tex
+++ b/docs/SuppInfo/body.tex
@@ -21,3 +21,7 @@
 \chapter{Streamflow Routing Package}
 \label{ch:sfr}
 \input{sfr.tex}
+
+\chapter{Multi-Aquifer Well Package}
+\label{ch:maw}
+\input{maw.tex}

--- a/docs/SuppInfo/maw.tex
+++ b/docs/SuppInfo/maw.tex
@@ -1,6 +1,6 @@
 A multi-aquifer well head is a dependent variable of the simulation, as a lake stage is, but the Multi-Aquifer Well (MAW) Package differs from the Lake (LAK) Package in where that variable is solved. \mf{} adds one equation per well to the groundwater flow matrix and solves the well head with the cell heads. The matrix the adjoint is taken from therefore already carries the well, and nothing has to be bordered onto it. This chapter describes what the adjoint supplies instead: the right-hand side of the rows the wells occupy, and the derivative of a measure of the exchange between a well and the aquifer.
 
-\section*{A system that is already bordered}
+\section*{Equations already in the matrix}
 
 Let $\mathbf{h}$ be the cell heads and $\mathbf{H}$ the heads of the multi-aquifer wells. The system \mf{} assembles is
 

--- a/docs/SuppInfo/maw.tex
+++ b/docs/SuppInfo/maw.tex
@@ -97,7 +97,9 @@ The four-step cases are the ones that carry the storage of equation~\ref{eqn:maw
 
 \section*{Sensitivity to the terms of the well}
 
-The rate a well is given enters only the equation of that well, so the sensitivity of a performance measure to it is the part of the adjoint solution belonging to the well, exactly as the sensitivity to the rate of a single-node well is the adjoint state of the cell that well is in.
+A well solves its head against the rate it is given, or holds the head it is given and solves for nothing. Only one of the two is a term of the model in either case, and an inactive well exchanges nothing, so neither is.
+
+The rate enters only the equation of that well, so the sensitivity of a performance measure to it is the part of the adjoint solution belonging to the well, exactly as the sensitivity to the rate of a single-node well is the adjoint state of the cell that well is in. Where the head is held instead, \mf{} has replaced that equation with the head it is given, and the sensitivity to that head is the same part of the adjoint solution with its sign reversed. Reporting the two as one quantity would give a well whose head is held a rate sensitivity it does not have, so they are kept apart, and each is zero for a well whose equation does not hold it.
 
 The conductance $C_{n,w}$ of a connection enters the equation of the cell and the equation of the well with opposite signs, and where the measure is of the exchange through that connection it also enters the measure directly, so
 
@@ -112,9 +114,9 @@ The conductance $C_{n,w}$ of a connection enters the equation of the cell and th
 
 A well whose head is held, or which is inactive, has no equation for the connection to enter, so $\lambda_{w}$ drops out of equation~\ref{eqn:maw-cond-sensitivity} and only the cell responds.
 
-Both quantities belong to the well or to the connection rather than to a cell, so neither maps onto the grid the way the sensitivity to a boundary value does. They are written beside the grid-shaped results, under the name of the package, with the well and cell numbers they belong to.
+All three quantities belong to a well or to a connection rather than to a cell, so none of them maps onto the grid the way the sensitivity to a boundary value does. They are written beside the grid-shaped results, under the name of the package, with the well and cell numbers they belong to.
 
-Against a central difference on a model whose connection conductances were given rather than computed from the well radius, both agree to four significant figures or better, for a well whose rate is specified over one time step and four, and for one whose head is held.
+Against a central difference, the rate and the held head agree to four significant figures or better over one time step and four, as does the conductance on a model whose connection conductances were given rather than computed from the well radius.
 
 \section*{What is not carried}
 

--- a/docs/SuppInfo/maw.tex
+++ b/docs/SuppInfo/maw.tex
@@ -1,0 +1,104 @@
+A multi-aquifer well head is a dependent variable of the simulation, as a lake stage is, but the Multi-Aquifer Well (MAW) Package differs from the Lake (LAK) Package in where that variable is solved. \mf{} adds one equation per well to the groundwater flow matrix and solves the well head with the cell heads. The matrix the adjoint is taken from therefore already carries the well, and nothing has to be bordered onto it. This chapter describes what the adjoint supplies instead: the right-hand side of the rows the wells occupy, and the derivative of a measure of the exchange between a well and the aquifer.
+
+\section*{A system that is already bordered}
+
+Let $\mathbf{h}$ be the cell heads and $\mathbf{H}$ the heads of the multi-aquifer wells. The system \mf{} assembles is
+
+\begin{equation}
+	\label{eqn:maw-system}
+	\begin{bmatrix}
+		\dfrac{\partial \mathbf{r}}{\partial \mathbf{h}} &
+		\dfrac{\partial \mathbf{r}}{\partial \mathbf{H}} \\[2ex]
+		\dfrac{\partial \mathbf{r}_{W}}{\partial \mathbf{h}} &
+		\dfrac{\partial \mathbf{r}_{W}}{\partial \mathbf{H}}
+	\end{bmatrix}
+	\begin{bmatrix} \mathbf{h} \\ \mathbf{H} \end{bmatrix}
+	=
+	\begin{bmatrix} \mathbf{b} \\ \mathbf{b}_{W} \end{bmatrix},
+\end{equation}
+
+\noindent where $\mathbf{r}$ is the aquifer residual of equation~\ref{eqn:residual}, and $\mathbf{r}_{W}$ is the water balance of the wells. Equation~\ref{eqn:maw-system} has the shape of the bordered system of equation~\ref{eqn:lak-bordered}, but every block of it comes from \mf{} rather than from the adjoint. All four are read from the assembled matrix and transposed with it.
+
+The whole of that matrix is available only where the row pointer and column index used to address it are the ones the solution was assembled with. The connectivity of the groundwater flow grid does not locate the entries of a matrix that a package has added equations to, because a well places a column inside the row of every cell it connects to and the grid connectivity does not count those entries.
+
+A well whose head is held constant, and one that is inactive, keep their row. \mf{} replaces the water balance of such a well with the head it is given, which leaves the row with nothing outside its diagonal, so the adjoint state of that well cannot travel back into the aquifer. No separate accounting is needed for either case.
+
+\section*{Measuring the exchange}
+
+The exchange between well $w$ and cell $n$ is
+
+\begin{equation}
+	\label{eqn:maw-exchange}
+	Q_{n,w} = C_{n,w}\left(h_{u}\right) \left( H_{w} - h_{n} \right),
+\end{equation}
+
+\noindent where $C_{n,w}$ is the conductance of the connection (L$^{2}$T$^{-1}$), $H_{w}$ is the head in the well (L), $h_{n}$ is the head in the cell (L), and $h_{u}$ is the larger of the two, the head on the upstream side of the connection.
+
+The conductance is not a constant. It follows $h_{u}$ through the fraction of the screen that is saturated over the interval the connection covers, so a performance measure of $Q_{n,w}$ has a derivative with respect to each head that carries two terms,
+
+\begin{equation}
+	\label{eqn:maw-derivative}
+	\frac{\partial Q_{n,w}}{\partial h_{n}} =
+	-C_{n,w} + \frac{\partial C_{n,w}}{\partial h_{n}}
+	\left( H_{w} - h_{n} \right), \qquad
+	\frac{\partial Q_{n,w}}{\partial H_{w}} =
+	C_{n,w} + \frac{\partial C_{n,w}}{\partial H_{w}}
+	\left( H_{w} - h_{n} \right),
+\end{equation}
+
+\noindent of which only one of the two conductance terms is present at a time, on whichever side is upstream. Equation~\ref{eqn:maw-derivative} is the same pair of terms that equation~\ref{eqn:formulation-jacobian} carries for the flow between two cells, and \mf{} assembles the second of them under the same conditions: under the Newton-Raphson formulation, and in a cell that converts between confined and unconfined. Under the standard formulation the conductance is lagged and the matrix holds it fixed, so a measure of the exchange holds it fixed as well, and the sensitivity is a partial derivative in the sense of Chapter~\ref{ch:formulation}.
+
+The first terms of equation~\ref{eqn:maw-derivative} sum to zero over the connections of a well whose rate is specified, because the exchange is then pinned by the rate and only its distribution between layers is free to move. A measure of the exchange at one cell is the difference of two large quantities, and the conductance terms, small beside either, are what is left of it. They cannot be dropped as a refinement.
+
+\section*{Well storage}
+
+A well stores water over its own cross-sectional area, so a transient step carries
+
+\begin{equation}
+	\label{eqn:maw-storage}
+	A_{w} \frac{H_{w}^{k} - H_{w}^{k-1}}{\Delta t}
+\end{equation}
+
+\noindent in the water balance of the well, where $A_{w}$ is the area of the well (L$^{2}$), $\Delta t$ is the length of the time step (T), and $k$ indexes the time step. The term links one time step to the next in the way the aquifer storage does, and the well part of the adjoint solution is carried backward the same way. An instantaneous measure, for which the time steps are independent, does not carry it (Chapter~\ref{ch:instantaneous}).
+
+\mf{} does not let the water level a well stores against fall below the bottom of the well, so a well whose head has left the screen releases nothing further as that head moves and carries nothing back. A steady-state step, and a well whose head is held or is inactive, carry nothing either.
+
+\section*{Verification}
+
+A well of radius 0.5 was screened through all three layers of a model 7 cells by 7 cells, withdrawing 300 in volume per unit time, with a second well withdrawing 50 from the upper layer away from it and a general-head boundary along one edge. Lengths and times are in the units of the model. The upper layer was about half saturated at the well, so the conductance of the upper connection was 55 against 525 and 1{,}469 for the two beneath it. The measure was the exchange between the well and the upper cell at the last time step, and its sensitivity to the rate of the second well was compared with a central difference between two forward runs.
+
+\begin{table}[htb]
+	\centering
+	\caption{Sensitivity of the exchange between a multi-aquifer well and the
+	cell it connects to in the upper layer, with respect to the rate of a second
+	well, against a finite-difference derivative. The last column holds the
+	conductance of the connection fixed, dropping the second terms of
+	equation~\ref{eqn:maw-derivative}.}
+	\label{tab:maw}
+	\small
+	\begin{tabular}{llrrr}
+		\toprule
+		Well & \shortstack[l]{Time\\steps} &
+		\shortstack[r]{Finite\\difference} &
+		\shortstack[r]{Adjoint} &
+		\shortstack[r]{Conductance\\held fixed} \\
+		\midrule
+		Specified rate & 1 & $1.7310 \times 10^{-3}$ & $1.7310 \times 10^{-3}$ & $6.9688 \times 10^{-3}$ \\
+		Specified rate & 4 & $8.4771 \times 10^{-4}$ & $8.4773 \times 10^{-4}$ & $6.8477 \times 10^{-3}$ \\
+		Specified head & 1 & $-2.2920 \times 10^{-2}$ & $-2.2920 \times 10^{-2}$ & $-2.0247 \times 10^{-2}$ \\
+		Specified head & 4 & $-2.7146 \times 10^{-2}$ & $-2.7146 \times 10^{-2}$ & $-2.4649 \times 10^{-2}$ \\
+		\bottomrule
+	\end{tabular}
+\end{table}
+
+The adjoint reproduces the finite-difference derivative to four significant figures or better in every case of table~\ref{tab:maw}. Holding the conductance fixed leaves an error of 9 to 12 percent where the head in the well is specified, and one of 300 to 700 percent where its rate is: with the rate specified the measure is what remains after the first terms of equation~\ref{eqn:maw-derivative} have cancelled, and the conductance terms are the whole of it.
+
+The four-step cases are the ones that carry the storage of equation~\ref{eqn:maw-storage} between time steps. Dropping that term leaves an error of 0.54 percent in the specified-rate case and none in the specified-head case, where the well has no water balance to store against.
+
+\section*{What is not carried}
+
+Water exchanged with a well by the Water Mover (MVR) Package follows the state of the package on the other side, and that derivative is not formed.
+
+A well whose rate follows its own head, through a pumping-rate reduction, a shutoff, or a flowing well, carries that dependence into the matrix only under the Newton-Raphson formulation. Under the standard formulation the rate is lagged, and the sensitivity is approximate in the way Chapter~\ref{ch:formulation} describes. Both conditions are reported.
+
+\mf{} releases through version 6.7.0 form a screen-saturation derivative for a connection in a cell that does not convert between confined and unconfined, where the conductance does not in fact follow the head. The matrix is then not the derivative of the equations the well solves, and a measure of the exchange at such a connection is approximate. The condition does not arise in a convertible cell, which is where a partly saturated screen occurs in any case.

--- a/docs/SuppInfo/maw.tex
+++ b/docs/SuppInfo/maw.tex
@@ -95,6 +95,27 @@ The adjoint reproduces the finite-difference derivative to four significant figu
 
 The four-step cases are the ones that carry the storage of equation~\ref{eqn:maw-storage} between time steps. Dropping that term leaves an error of 0.54 percent in the specified-rate case and none in the specified-head case, where the well has no water balance to store against.
 
+\section*{Sensitivity to the terms of the well}
+
+The rate a well is given enters only the equation of that well, so the sensitivity of a performance measure to it is the part of the adjoint solution belonging to the well, exactly as the sensitivity to the rate of a single-node well is the adjoint state of the cell that well is in.
+
+The conductance $C_{n,w}$ of a connection enters the equation of the cell and the equation of the well with opposite signs, and where the measure is of the exchange through that connection it also enters the measure directly, so
+
+\begin{equation}
+	\label{eqn:maw-cond-sensitivity}
+	\frac{\mathrm{d} f}{\mathrm{d} C_{n,w}} = f_{s} \left(
+	\lambda_{n} - \lambda_{w} + w_{n} \right)
+	\left( H_{w} - h_{n} \right),
+\end{equation}
+
+\noindent where $f$ is the performance measure, $\lambda_{n}$ and $\lambda_{w}$ are the parts of the adjoint solution belonging to the cell and to the well (dimensionless), $w_{n}$ is the weight the measure gives the exchange at that cell (dimensionless), and $f_{s}$ is the saturated fraction of the screen the connection covers (dimensionless). The last of these is there because \mf{} scales the conductance a connection is given by that fraction before it uses it, and the value a sensitivity is reported for is the one given.
+
+A well whose head is held, or which is inactive, has no equation for the connection to enter, so $\lambda_{w}$ drops out of equation~\ref{eqn:maw-cond-sensitivity} and only the cell responds.
+
+Both quantities belong to the well or to the connection rather than to a cell, so neither maps onto the grid the way the sensitivity to a boundary value does. They are written beside the grid-shaped results, under the name of the package, with the well and cell numbers they belong to.
+
+Against a central difference on a model whose connection conductances were given rather than computed from the well radius, both agree to four significant figures or better, for a well whose rate is specified over one time step and four, and for one whose head is held.
+
 \section*{What is not carried}
 
 Water exchanged with a well by the Water Mover (MVR) Package follows the state of the package on the other side, and that derivative is not formed.

--- a/mf6adj/adj.py
+++ b/mf6adj/adj.py
@@ -13,7 +13,11 @@ import numpy as np
 import pandas as pd
 from xmipy.errors import XMIError
 
-from .advanced_packages import lake_forward_terms, sfr_forward_terms
+from .advanced_packages import (
+    lake_forward_terms,
+    maw_forward_terms,
+    sfr_forward_terms,
+)
 from .packages import storage
 from .packages.head_dependent import DRAIN_CORNER_TOL
 from .pm import PerfMeas, PerfMeasRecord
@@ -45,6 +49,11 @@ DT_FMT = "%Y-%m-%d %H:%M:%S"
 # Array-based recharge is named rch6 in the name file as the list form is, so
 # both are covered by the one entry.
 SPECIFIED_FLUX_PACKAGES = ("wel6", "rch6")
+
+# Package types that add their own equations to the solution matrix and whose
+# terms the adjoint forms. A package that adds equations and is not here leaves
+# the adjoint with rows it cannot fill.
+COUPLED_PACKAGE_TYPES = ("maw6",)
 PathLike = Union[str, pl.Path]
 
 
@@ -183,16 +192,24 @@ class Mf6Adj:
             }
 
     def _check_solution_coupling(self) -> None:
-        """Raise if a package adds its own equations to the solution matrix.
+        """Raise if a package adds equations the adjoint forms no terms for.
+
+        The adjoint takes its matrix from the one MODFLOW assembled, so a
+        package that adds its own equations puts them in that matrix already.
+        What the adjoint has to supply is the right-hand side of those rows and
+        the state they carry between time steps, and it does that only for the
+        packages named here.
 
         Raises
         ------
         Exception
-            If any package contributes equations to the solution matrix.
+            If a package contributes equations whose terms are not formed.
         """
         coupled = []
         for package_type, tags in self._gwf_package_dict.items():
             for tag in tags:
+                if package_type in COUPLED_PACKAGE_TYPES:
+                    continue
                 try:
                     npakeq = self._gwf.get_value(
                         self._gwf.get_var_address("NPAKEQ", self._gwf_name, tag.upper())
@@ -205,13 +222,13 @@ class Mf6Adj:
 
         if coupled:
             raise Exception(
-                "the adjoint matrix is rebuilt from the groundwater flow grid "
-                "connectivity, so packages that add their own equations to the "
-                "solution matrix are not supported yet: "
+                "a package that adds its own equations to the solution matrix "
+                "is supported only where the adjoint forms the terms of those "
+                "equations, which it does not for: "
                 + f"{', '.join(coupled)}. An implicitly coupled lake (MODFLOW 6 "
-                "6.8.0 and later) and maw6 both add equations; use an "
-                "explicitly coupled lake and represent multi-aquifer wells "
-                "with wel6."
+                "6.8.0 and later) adds equations; use an explicitly coupled "
+                "lake. The supported coupled package types are "
+                + f"{', '.join(COUPLED_PACKAGE_TYPES)}."
             )
 
     def _add_performance_measure(
@@ -895,6 +912,12 @@ class Mf6Adj:
                                             self._gwf, self._gwf_name, tag
                                         )
                                     )
+                                if package_type == "maw6":
+                                    data_dict[tag].update(
+                                        maw_forward_terms(
+                                            self._gwf, self._gwf_name, tag
+                                        )
+                                    )
                 attr_dict = {
                     "ctime": ctime,
                     "dt": dt1,
@@ -1208,7 +1231,16 @@ class Mf6Adj:
         for paktype, pdict in org_sp_package_data.items():
             if paktype == "chd6":
                 continue
-            pert_items = self._gwf_boundary_attr_dict[paktype]
+            # a perturbation moves a value the boundary is given, and an
+            # advanced package exchanges water through a state it solves
+            # instead, which leaves it nothing to perturb
+            pert_items = self._gwf_boundary_attr_dict.get(paktype)
+            if not pert_items:
+                self.logger.logger.info(
+                    f"Skipping perturbations for {paktype}, which has no "
+                    "boundary values to perturb"
+                )
+                continue
             epsilons = []
             node_ids = []
             names = []

--- a/mf6adj/advanced_packages/__init__.py
+++ b/mf6adj/advanced_packages/__init__.py
@@ -1,21 +1,28 @@
 """Adjoint coupling for the MODFLOW 6 advanced packages.
 
 An advanced package carries its own dependent variable - a lake stage, a reach
-stage - solved in the outer iteration rather than in the solution matrix.
-Holding that variable fixed gives a partial derivative, so the adjoint system
-is bordered with the package's own equation. Each package keeps its terms in a
-module here, leaving the adjoint solver free of package detail.
+stage, a well head. Holding that variable fixed gives a partial derivative, so
+the package's own equation has to be part of the adjoint system. A lake or a
+reach is solved in the outer iteration rather than in the solution matrix, so
+the adjoint system is bordered with its equation; a multi-aquifer well is
+solved with the flow equations, so its equation is already a row of the matrix.
+Each package keeps its terms in a module here, leaving the adjoint solver free
+of package detail.
 """
 
 from .lake import LakeCoupling, table_slope
 from .lake import forward_terms as lake_forward_terms
+from .maw import MawCoupling
+from .maw import forward_terms as maw_forward_terms
 from .sfr import SfrCoupling
 from .sfr import forward_terms as sfr_forward_terms
 
 __all__ = [
     "LakeCoupling",
+    "MawCoupling",
     "SfrCoupling",
     "lake_forward_terms",
+    "maw_forward_terms",
     "sfr_forward_terms",
     "table_slope",
 ]

--- a/mf6adj/advanced_packages/maw.py
+++ b/mf6adj/advanced_packages/maw.py
@@ -1,0 +1,406 @@
+"""Multi-aquifer well (MAW) coupling for the adjoint solution.
+
+A multi-aquifer well head is a dependent variable, and MODFLOW solves it with
+the flow equations rather than outside them, so the well's equation is already
+one of the rows of the matrix the adjoint is taken from. Unlike a lake or a
+reach, nothing here has to border the system or rebuild the well's equation.
+
+What is left is the row each well occupies, the derivative of a performance
+measure with respect to the well head, and the storage the well carries from
+one time step to the next.
+"""
+
+import numpy as np
+
+# MODFLOW 6 marks a well option that was not given with this value
+NOT_SET = 1.0e20
+
+
+def saturation_derivative(top, bot, x, eps):
+    """Return the slope of the smoothed screen saturation with head.
+
+    This is the derivative MODFLOW 6 forms for a multi-aquifer well connection
+    under the Newton-Raphson formulation, over the interval of the screen that
+    the connection covers. Away from the ends of that interval the saturation
+    follows the head linearly; MODFLOW rounds the two corners over a fraction
+    ``eps`` of the interval, and the slope follows that rounding.
+
+    Parameters
+    ----------
+    top : ndarray
+        Top of the screen interval.
+    bot : ndarray
+        Bottom of the screen interval.
+    x : ndarray
+        Upstream head.
+    eps : float
+        Smoothing fraction, the package's ``satomega``.
+
+    Returns
+    -------
+    ndarray
+        Slope of the saturation with respect to the upstream head.
+    """
+    thickness = np.asarray(top - bot, dtype=float)
+    over = np.divide(
+        x - bot, thickness, out=np.zeros_like(thickness), where=thickness > 0.0
+    )
+    fraction = np.clip(over, 0.0, 1.0)
+    scale = 1.0 / (1.0 - eps) if eps < 1.0 else 1.0
+    slope = np.full(fraction.shape, scale)
+    if eps > 0.0:
+        slope = np.where(fraction < eps, scale * fraction / eps, slope)
+        slope = np.where(fraction > 1.0 - eps, scale * (1.0 - fraction) / eps, slope)
+    slope = np.where(fraction >= 1.0, 0.0, slope)
+    return np.divide(
+        slope, thickness, out=np.zeros_like(thickness), where=thickness > 0.0
+    )
+
+
+def forward_terms(gwf, gwf_name: str, tag: str) -> dict:
+    """Return the well terms of a multi-aquifer well package for one time step.
+
+    Parameters
+    ----------
+    gwf : modflowapi.ModflowApi
+        MODFLOW 6 groundwater-flow instance.
+    gwf_name : str
+        Name of the groundwater-flow model.
+    tag : str
+        Multi-aquifer well package name from the GWF name file.
+
+    Returns
+    -------
+    dict
+        The solution row of each well, the well each connection belongs to,
+        the conductance of each connection, and the terms of the well's own
+        storage. ``well_is_free`` marks a well whose head is solved, as opposed
+        to one held constant or inactive. ``well_rate_limited`` marks a package
+        whose rate follows the well head through a shutoff, a pumping-rate
+        reduction, or a flowing well.
+    """
+
+    def value(name):
+        return gwf.get_value(gwf.get_var_address(name, gwf_name, tag.upper())).copy()
+
+    def optional(name, default, size):
+        """Return a package quantity, or a default where MODFLOW omits it."""
+        try:
+            return value(name)
+        except Exception:
+            return np.full(size, default)
+
+    # IDXLOCNODE is the one-based row the well's equation occupies in the
+    # solution, which already counts the wells of any package before it
+    row = value("IDXLOCNODE") - 1
+    nwells = row.shape[0]
+    # IMAP is the one-based well each connection belongs to
+    well_of_conn = value("IMAP") - 1
+
+    # MODFLOW keeps a well's status in the model ibound, in the entry for the
+    # row its equation occupies: zero for an inactive well and negative for one
+    # held at a constant head, neither of which has a water balance to solve
+    ibound = gwf.get_value(gwf.get_var_address("IBOUND", gwf_name))
+    is_free = (ibound[row] > 0).astype(int)
+
+    # The well stores water over its own area, and MODFLOW clips the head it
+    # stores against to the screen, so a well whose head left the screen
+    # between the two steps stores nothing more as that head moves.
+    head_old = value("XOLDPAK")
+    head_sto_old = value("XOLDSTO")
+    stores = is_free * (head_sto_old == head_old)
+
+    # A connection's conductance follows the upstream head through the
+    # saturated fraction of the screen it covers, so the exchange follows that
+    # head twice over. MODFLOW carries the second part in the matrix under the
+    # Newton-Raphson formulation, and a measure of the exchange needs it too.
+    # Under the standard formulation the conductance is lagged instead, and the
+    # matrix holds it fixed, so the measure holds it fixed as well.
+    cond = value("SIMCOND")
+    head = value("HEAD")
+    node = value("NODELIST") - 1
+    hgwf = gwf.get_value(gwf.get_var_address("X", gwf_name))[node]
+    hmaw = head[well_of_conn]
+    # the derivative attaches to whichever side is upstream
+    maw_upstream = hmaw > hgwf
+    # MODFLOW pins the saturation at one in a cell it does not convert, where
+    # the conductance is the full thickness and does not follow the head
+    icelltype = gwf.get_value(gwf.get_var_address("ICELLTYPE", gwf_name, "NPF"))
+    if int(value("INEWTON")[0]) != 0:
+        dsatdh = saturation_derivative(
+            value("TOPSCRN"),
+            value("BOTSCRN"),
+            np.maximum(hmaw, hgwf),
+            float(value("SATOMEGA")[0]),
+        )
+        # the same term MODFLOW forms: the slope of the conductance times the
+        # head difference that drives the exchange
+        dterm = np.where(
+            icelltype[node] != 0,
+            dsatdh * value("SATCOND") * (hgwf - hmaw),
+            0.0,
+        )
+    else:
+        dterm = np.zeros_like(cond)
+
+    # a rate that follows the well head is in the well's equation only where
+    # MODFLOW assembled its derivative, which is the Newton-Raphson formulation
+    limited = (
+        (optional("SHUTOFFLEVEL", NOT_SET, nwells) < NOT_SET)
+        | (optional("PUMPELEV", NOT_SET, nwells) < NOT_SET)
+        | (optional("REDUCTION_LENGTH", NOT_SET, nwells) < NOT_SET)
+        | (optional("FWCONDSIM", 0.0, nwells) > 0.0)
+    ).astype(int)
+
+    return {
+        "well_area": value("AREA"),
+        "well_cond": cond,
+        "well_dterm": dterm,
+        "well_head": head,
+        "well_maw_upstream": maw_upstream.astype(int),
+        "well_head_old": head_old,
+        "well_is_free": is_free,
+        "well_imover": np.full(nwells, int(optional("IMOVER", 0, 1)[0]), dtype=int),
+        "well_iss": np.full(nwells, int(value("IMAWISS")[0]), dtype=int),
+        "well_of_conn": well_of_conn,
+        "well_rate_limited": limited,
+        "well_row": row,
+        "well_stores": stores,
+    }
+
+
+class MawCoupling:
+    """The multi-aquifer well rows of the adjoint system.
+
+    One instance follows a performance measure through its backward sweep and
+    holds the state that spans time steps: the row each well occupies and the
+    storage each carries back to the previous step.
+    """
+
+    def __init__(self, logger=None):
+        """Initialize the coupling.
+
+        Parameters
+        ----------
+        logger : object, optional
+            Logger used to report where a well is only partly differentiated.
+        """
+        self.logger = logger
+        self.carry = {}
+        self.rows = {}
+        self._warned = set()
+
+    def reset_step(self) -> None:
+        """Forget the previous time step's well state."""
+        self.rows = {}
+        self.carry = {}
+
+    def _warn(self, message: str) -> None:
+        if self.logger is not None:
+            self.logger.warning(message)
+
+    def _warn_once(self, pname: str, grp, is_newton: bool) -> None:
+        """Warn where a well's equation is differentiated only in part."""
+        if pname in self._warned:
+            return
+        self._warned.add(pname)
+
+        if not is_newton and grp["well_rate_limited"][:].max() > 0:
+            self._warn(
+                f"multi-aquifer well package '{pname}' limits a rate on the "
+                "well head, through a shutoff, a pumping-rate reduction, or a "
+                "flowing well, and the flow model did not use the "
+                "Newton-Raphson formulation, so the matrix does not carry how "
+                "that limit follows the head and the sensitivity is "
+                "approximate."
+            )
+
+        if grp["well_imover"][:].max() > 0:
+            self._warn(
+                f"multi-aquifer well package '{pname}' exchanges water through "
+                "the mover. That flow follows the state of the package on the "
+                "other side, and the derivative is not formed, so the "
+                "sensitivity is approximate."
+            )
+
+    def blocks(self, sol_dataset, gwf_package_dict, is_newton=True) -> list:
+        """Return the wells and the terms coupling them to the aquifer.
+
+        Parameters
+        ----------
+        sol_dataset : h5py.Group
+            Forward-solution group for one time step.
+        gwf_package_dict : dict
+            Mapping of package types to package names.
+        is_newton : bool, optional
+            Whether the flow model used the Newton-Raphson formulation.
+
+        Returns
+        -------
+        list
+            One entry per multi-aquifer well package.
+        """
+        found = []
+        for ptype, pnames in gwf_package_dict.items():
+            if ptype != "maw6":
+                continue
+            for pname in pnames:
+                if pname not in sol_dataset:
+                    continue
+                grp = sol_dataset[pname]
+                if "well_row" not in grp:
+                    continue
+
+                self._warn_once(pname, grp, is_newton)
+
+                found.append(
+                    {
+                        "name": pname,
+                        "node": grp["nodelist"][:] - 1,
+                        "cond": grp["well_cond"][:],
+                        "area": grp["well_area"][:],
+                        "dterm": grp["well_dterm"][:],
+                        "maw_upstream": grp["well_maw_upstream"][:] == 1,
+                        "free": grp["well_is_free"][:] == 1,
+                        "iss": grp["well_iss"][:],
+                        "row": grp["well_row"][:],
+                        "stores": grp["well_stores"][:],
+                        "well_of_conn": grp["well_of_conn"][:],
+                    }
+                )
+        return found
+
+    def claimed_rows(self, blocks) -> set:
+        """Return the solution rows the wells of these packages occupy."""
+        claimed = set()
+        for block in blocks:
+            claimed.update(int(row) for row in block["row"])
+        return claimed
+
+    @staticmethod
+    def _weights(entries, kk, block) -> dict:
+        """Return the weight this measure gives each node of one package."""
+        return {
+            pfr.inode: pfr.weight
+            for pfr in entries
+            if pfr.kperkstp == kk and pfr.pm_type == block["name"]
+        }
+
+    def dfds(self, entries, kk, blocks) -> dict:
+        """Return the derivative of the measure with respect to each well head.
+
+        A flux measure on a multi-aquifer well sums the exchange at the cells
+        it names, and that exchange depends on the well head as well as on the
+        head in the cell. Where the well is the upstream side, it also sets the
+        conductance, and that part is carried too.
+
+        Returns
+        -------
+        dict
+            ``(package name, well)`` mapped to the derivative.
+        """
+        result = {}
+        for block in blocks:
+            weights = self._weights(entries, kk, block)
+            if not weights:
+                continue
+            for iconn in range(block["node"].shape[0]):
+                node = int(block["node"][iconn])
+                if node not in weights:
+                    continue
+                key = (block["name"], int(block["well_of_conn"][iconn]))
+                value = float(block["cond"][iconn])
+                if block["maw_upstream"][iconn]:
+                    value -= float(block["dterm"][iconn])
+                result[key] = result.get(key, 0.0) + weights[node] * value
+        return result
+
+    def measure_dfdh(self, entries, kk, blocks, nnodes) -> np.ndarray:
+        """Return what a measure adds to the derivative with respect to head.
+
+        The exchange follows the head in the cell twice over: through the head
+        difference, which the package hcof already carries, and through the
+        conductance, where the cell is the upstream side. Only the second is
+        returned here.
+
+        Returns
+        -------
+        ndarray
+            Addition to the derivative of the measure with respect to head.
+        """
+        result = np.zeros(int(nnodes))
+        for block in blocks:
+            weights = self._weights(entries, kk, block)
+            if not weights:
+                continue
+            for iconn in range(block["node"].shape[0]):
+                node = int(block["node"][iconn])
+                if node not in weights or block["maw_upstream"][iconn]:
+                    continue
+                result[node] -= weights[node] * float(block["dterm"][iconn])
+        return result
+
+    def fill(self, rhs, blocks, dfds) -> np.ndarray:
+        """Put the well rows of the right-hand side in place.
+
+        The rows the wells occupy are already in the matrix, so only their
+        right-hand side is formed here: the carry-back from the later time step
+        minus the measure's own derivative, the same convention the aquifer
+        rows use.
+
+        Returns
+        -------
+        ndarray
+            The right-hand side, with the well rows filled in place.
+        """
+        self.rows = {}
+        for block in blocks:
+            for iwell in range(block["row"].shape[0]):
+                key = (block["name"], iwell)
+                irow = int(block["row"][iwell])
+                self.rows[key] = irow
+                rhs[irow] = self.carry.get(key, 0.0) - dfds.get(key, 0.0)
+        return rhs
+
+    def split(self, lamb, blocks, dt, nnodes, carry_back=True) -> np.ndarray:
+        """Take the well heads off the solution and carry their storage back.
+
+        Parameters
+        ----------
+        lamb : ndarray
+            The solved adjoint state, aquifer rows first.
+        blocks : list
+            The well packages of this time step.
+        dt : float
+            Length of this time step.
+        nnodes : int
+            Number of aquifer rows.
+        carry_back : bool
+            False for a steady-state step, and for an instantaneous measure,
+            where each time step is solved on its own.
+
+        Returns
+        -------
+        ndarray
+            The aquifer part of the adjoint state.
+        """
+        self.carry = {}
+        if carry_back and dt > 0.0:
+            for block in blocks:
+                for key, irow in self.rows.items():
+                    if key[0] != block["name"]:
+                        continue
+                    iwell = key[1]
+                    # a steady-state well has no change in storage, and a well
+                    # whose head is held or is inactive has no equation to
+                    # carry, which MODFLOW marks by clipping the head it
+                    # stores against
+                    if block["iss"][iwell] != 0 or not block["stores"][iwell]:
+                        continue
+                    # MODFLOW releases the storage of the previous step into
+                    # the right-hand side of this one, so the derivative of
+                    # that side with respect to the previous head is negative,
+                    # as it is for the aquifer
+                    area = float(block["area"][iwell])
+                    self.carry[key] = -area / dt * lamb[irow]
+        return lamb[:nnodes]

--- a/mf6adj/advanced_packages/maw.py
+++ b/mf6adj/advanced_packages/maw.py
@@ -98,10 +98,13 @@ def forward_terms(gwf, gwf_name: str, tag: str) -> dict:
     well_of_conn = value("IMAP") - 1
 
     # MODFLOW keeps a well's status in the model ibound, in the entry for the
-    # row its equation occupies: zero for an inactive well and negative for one
-    # held at a constant head, neither of which has a water balance to solve
+    # row its equation occupies: positive for a well whose head is solved, zero
+    # for an inactive one, and negative for one held at a constant head. Only
+    # the first has a water balance to solve, and the sign separates the other
+    # two, which do not have the same terms.
     ibound = gwf.get_value(gwf.get_var_address("IBOUND", gwf_name))
-    is_free = (ibound[row] > 0).astype(int)
+    status = ibound[row]
+    is_free = (status > 0).astype(int)
 
     # The well stores water over its own area, and MODFLOW clips the head it
     # stores against to the screen, so a well whose head left the screen
@@ -170,6 +173,7 @@ def forward_terms(gwf, gwf_name: str, tag: str) -> dict:
         "well_of_conn": well_of_conn,
         "well_rate_limited": limited,
         "well_row": row,
+        "well_status": status,
         "well_sat": sat,
         "well_stores": stores,
     }
@@ -271,6 +275,7 @@ class MawCoupling:
                         "free": grp["well_is_free"][:] == 1,
                         "iss": grp["well_iss"][:],
                         "row": grp["well_row"][:],
+                        "status": grp["well_status"][:],
                         "sat": grp["well_sat"][:],
                         "stores": grp["well_stores"][:],
                         "well_of_conn": grp["well_of_conn"][:],
@@ -373,9 +378,19 @@ class MawCoupling:
     def sensitivities(self, lamb, head, blocks, entries, kk) -> dict:
         """Return the sensitivity of the measure to the terms of each package.
 
-        The rate a well is given enters only its own equation, so the
-        sensitivity to it is the adjoint state of that equation. The
-        conductance of a connection enters the equation of the cell and the
+        A well solves its head against the rate it is given, or holds the head
+        it is given and solves for nothing. Only one of the two is a term of
+        the model in either case, and an inactive well exchanges nothing, so
+        neither is. The two are reported separately rather than as one number
+        whose meaning changes with the status of the well.
+
+        The rate enters only the well's own equation, so the sensitivity to it
+        is the adjoint state of that equation. Where the head is held instead,
+        MODFLOW has replaced that equation with the head it is given, and the
+        sensitivity to that head is the same adjoint state with its sign
+        reversed.
+
+        The conductance of a connection enters the equation of the cell and the
         equation of the well with opposite signs, and a measure of the exchange
         through that connection depends on it directly as well.
 
@@ -397,13 +412,17 @@ class MawCoupling:
         -------
         dict
             Package name mapped to the well numbers, the nodes the connections
-            reach, and the sensitivity to the rate of each well and to the
+            reach, the sensitivity to the rate of each well and to the head of
+            each well that is held at one, and the sensitivity to the
             conductance of each connection.
         """
         result = {}
         for block in blocks:
             weights = self._weights(entries, kk, block)
-            rate = np.array([lamb[int(row)] for row in block["row"]], dtype=float)
+            state = np.array([lamb[int(row)] for row in block["row"]], dtype=float)
+            status = block["status"]
+            rate = np.where(status > 0, state, 0.0)
+            well_head = np.where(status < 0, -state, 0.0)
             cond = np.zeros(block["node"].shape[0])
             for iconn in range(block["node"].shape[0]):
                 node = int(block["node"][iconn])
@@ -413,7 +432,7 @@ class MawCoupling:
                 drop = float(block["head"][iwell]) - float(head[node])
                 # a well whose head is held or is inactive has no equation for
                 # the connection to enter, so only the cell it reaches responds
-                well = rate[iwell] if block["free"][iwell] else 0.0
+                well = state[iwell] if block["free"][iwell] else 0.0
                 # the conductance a user gives is scaled by the saturated
                 # fraction of the screen before MODFLOW uses it
                 cond[iconn] = float(block["sat"][iconn]) * (
@@ -423,6 +442,7 @@ class MawCoupling:
                 "well": np.arange(block["row"].shape[0]) + 1,
                 "node": block["node"] + 1,
                 "rate": rate,
+                "head": well_head,
                 "cond": cond,
             }
         return result

--- a/mf6adj/advanced_packages/maw.py
+++ b/mf6adj/advanced_packages/maw.py
@@ -117,6 +117,11 @@ def forward_terms(gwf, gwf_name: str, tag: str) -> dict:
     # Under the standard formulation the conductance is lagged instead, and the
     # matrix holds it fixed, so the measure holds it fixed as well.
     cond = value("SIMCOND")
+    # MODFLOW scales the conductance a connection is given by the saturated
+    # fraction of the screen, so a sensitivity to the value the user gives
+    # carries that fraction
+    satcond = value("SATCOND")
+    sat = np.divide(cond, satcond, out=np.ones_like(cond), where=satcond > 0.0)
     head = value("HEAD")
     node = value("NODELIST") - 1
     hgwf = gwf.get_value(gwf.get_var_address("X", gwf_name))[node]
@@ -165,6 +170,7 @@ def forward_terms(gwf, gwf_name: str, tag: str) -> dict:
         "well_of_conn": well_of_conn,
         "well_rate_limited": limited,
         "well_row": row,
+        "well_sat": sat,
         "well_stores": stores,
     }
 
@@ -260,10 +266,12 @@ class MawCoupling:
                         "cond": grp["well_cond"][:],
                         "area": grp["well_area"][:],
                         "dterm": grp["well_dterm"][:],
+                        "head": grp["well_head"][:],
                         "maw_upstream": grp["well_maw_upstream"][:] == 1,
                         "free": grp["well_is_free"][:] == 1,
                         "iss": grp["well_iss"][:],
                         "row": grp["well_row"][:],
+                        "sat": grp["well_sat"][:],
                         "stores": grp["well_stores"][:],
                         "well_of_conn": grp["well_of_conn"][:],
                     }
@@ -361,6 +369,63 @@ class MawCoupling:
                 self.rows[key] = irow
                 rhs[irow] = self.carry.get(key, 0.0) - dfds.get(key, 0.0)
         return rhs
+
+    def sensitivities(self, lamb, head, blocks, entries, kk) -> dict:
+        """Return the sensitivity of the measure to the terms of each package.
+
+        The rate a well is given enters only its own equation, so the
+        sensitivity to it is the adjoint state of that equation. The
+        conductance of a connection enters the equation of the cell and the
+        equation of the well with opposite signs, and a measure of the exchange
+        through that connection depends on it directly as well.
+
+        Parameters
+        ----------
+        lamb : ndarray
+            The solved adjoint state, aquifer rows first, before the well rows
+            are taken off.
+        head : ndarray
+            Simulated head for every node.
+        blocks : list
+            The well packages of this time step.
+        entries : list
+            Entries of the performance measure.
+        kk : tuple
+            Zero-based stress period and time step.
+
+        Returns
+        -------
+        dict
+            Package name mapped to the well numbers, the nodes the connections
+            reach, and the sensitivity to the rate of each well and to the
+            conductance of each connection.
+        """
+        result = {}
+        for block in blocks:
+            weights = self._weights(entries, kk, block)
+            rate = np.array([lamb[int(row)] for row in block["row"]], dtype=float)
+            cond = np.zeros(block["node"].shape[0])
+            for iconn in range(block["node"].shape[0]):
+                node = int(block["node"][iconn])
+                iwell = int(block["well_of_conn"][iconn])
+                # the head difference that drives the exchange, which is what
+                # a unit of conductance carries
+                drop = float(block["head"][iwell]) - float(head[node])
+                # a well whose head is held or is inactive has no equation for
+                # the connection to enter, so only the cell it reaches responds
+                well = rate[iwell] if block["free"][iwell] else 0.0
+                # the conductance a user gives is scaled by the saturated
+                # fraction of the screen before MODFLOW uses it
+                cond[iconn] = float(block["sat"][iconn]) * (
+                    (lamb[node] - well + weights.get(node, 0.0)) * drop
+                )
+            result[block["name"]] = {
+                "well": np.arange(block["row"].shape[0]) + 1,
+                "node": block["node"] + 1,
+                "rate": rate,
+                "cond": cond,
+            }
+        return result
 
     def split(self, lamb, blocks, dt, nnodes, carry_back=True) -> np.ndarray:
         """Take the well heads off the solution and carry their storage back.

--- a/mf6adj/pm.py
+++ b/mf6adj/pm.py
@@ -1102,10 +1102,12 @@ class PerfMeas:
                             "well": values["well"],
                             "node": values["node"],
                             "rate": np.zeros_like(values["rate"]),
+                            "head": np.zeros_like(values["head"]),
                             "cond": np.zeros_like(values["cond"]),
                         },
                     )
                     totals["rate"] += values["rate"] * w
+                    totals["head"] += values["head"] * w
                     totals["cond"] += values["cond"] * w
                 # the well rows are the innermost, being MODFLOW's own, and the
                 # well carries its storage back the way the aquifer does
@@ -1336,6 +1338,7 @@ class PerfMeas:
                 comp_bnd_results[name] /= wsum
             for totals in comp_maw_results.values():
                 totals["rate"] /= wsum
+                totals["head"] /= wsum
                 totals["cond"] /= wsum
         data = {}
         data["k11"] = comp_k_sens

--- a/mf6adj/pm.py
+++ b/mf6adj/pm.py
@@ -21,7 +21,7 @@ from scipy.sparse.linalg import (
     svds,
 )
 
-from .advanced_packages import LakeCoupling, SfrCoupling
+from .advanced_packages import LakeCoupling, MawCoupling, SfrCoupling
 from .packages import head_dependent, npf, recharge, well
 from .packages.head_dependent import DRAIN_CORNER_TOL, drop_corner_entries
 from .utils.utils import SolverCallback
@@ -656,22 +656,16 @@ class PerfMeas:
         # scalar for slicing the bordered solution.
         nnode = int(np.asarray(nnodes).ravel()[0])
 
-        # A package that adds its own equations puts them after the aquifer
-        # rows of the solution. Nothing forms their side of the adjoint yet,
-        # so refuse rather than solve a system that is short of equations.
-        # Mf6Adj rejects such a model as it reads it; this is the same
-        # condition seen from the forward solution file.
+        # A package that adds its own equations to the solution puts them after
+        # the aquifer rows. They are already in the matrix; what the adjoint
+        # supplies is their right-hand side, which it does only for the
+        # packages that have a coupling here.
         nsln = len(sln_ia) - 1
-        if nsln > nnode:
-            raise Exception(
-                "the matrix MODFLOW assembled has "
-                + f"{nsln - nnode} equations beyond the {nnode} of the flow "
-                + "grid, which a package such as maw6 added to the solution. "
-                + "The adjoint does not form the terms for those equations yet."
-            )
         if nsln < nnode:
             # the solution holds one equation per cell and one for every
-            # equation a package adds, so it is never short of the grid
+            # equation a package adds, so it is never short of the grid. A
+            # solution larger than the grid is a package that added equations,
+            # and which rows those are is checked at each time step.
             raise Exception(
                 f"the matrix MODFLOW assembled has {nsln} equations, fewer "
                 + f"than the {nnode} of the flow grid, so the sparsity in "
@@ -679,6 +673,7 @@ class PerfMeas:
                 + "not belong to that grid."
             )
         self._lake = LakeCoupling(logger=self.logger.logger)
+        self._maw = MawCoupling(logger=self.logger.logger)
         self._sfr = SfrCoupling(logger=self.logger.logger)
 
         bnd_dict = get_mf6_bound_dict()
@@ -715,6 +710,8 @@ class PerfMeas:
                 raise Exception(
                     f"solution key '{sol_key}' already in adjoint hdf5 file"
                 )
+
+            is_newton = hdf[sol_key].attrs["is_newton"]
 
             start = datetime.now()
             self.logger.logger.debug("Forming rhs")
@@ -766,27 +763,56 @@ class PerfMeas:
             amat = assemble_matrix(amat, sln_ia, sln_ja)
             amat = amat.transpose().tocsr()
 
+            # A multi-aquifer well head is solved with the flow equations, so
+            # the well's own equation is already a row of amat and only its
+            # right-hand side is formed here. The rows sit after the aquifer's,
+            # and the lake and reach rows border whatever they leave.
+            dt = float(hdf[sol_key].attrs["dt"])
+            maw_blocks = self._maw.blocks(hdf[sol_key], gwf_package_dict, is_newton)
+            rhs = np.concatenate((rhs, np.zeros(nsln - nnode)))
+            unclaimed = set(range(nnode, nsln)) - self._maw.claimed_rows(maw_blocks)
+            if unclaimed:
+                raise Exception(
+                    "the matrix MODFLOW assembled has "
+                    + f"{len(unclaimed)} equations beyond the {nnode} of the "
+                    + "flow grid that no package accounts for. The adjoint "
+                    + "does not form the terms for those equations."
+                )
+            if not maw_blocks:
+                self._maw.reset_step()
+            else:
+                # a measure of the exchange follows the head in the cell
+                # through the conductance as well as through the head
+                # difference, and only the second is in the package hcof
+                rhs[:nnode] -= self._maw.measure_dfdh(
+                    self._entries, kk, maw_blocks, nnode
+                )
+                rhs = self._maw.fill(
+                    rhs,
+                    maw_blocks,
+                    self._maw.dfds(self._entries, kk, maw_blocks),
+                )
+
             # the lake state is per time step: a step with no free lake must
             # not inherit the previous step's columns, carry, or solution size
-            # a steady-state step has no change in lake storage, so it has no
+            # a steady-state step has no change in storage, so it has no
             # storage on the diagonal and nothing to carry. An instantaneous
-            # measure keeps the storage, because that is part of the lake's
+            # measure keeps the storage, because that is part of the package's
             # equation at this step, but is solved without the carry.
-            lake_storage = hdf[sol_key]["iss"][0] == 0
-            lake_carry_back = lake_storage and not is_instantaneous
+            is_transient = hdf[sol_key]["iss"][0] == 0
+            carry_back = is_transient and not is_instantaneous
             lake_blocks = self._lake.blocks(hdf[sol_key], gwf_package_dict)
             if not lake_blocks:
                 self._lake.reset_step()
             else:
-                dt = float(hdf[sol_key].attrs["dt"])
                 amat, rhs = self._lake.augment(
                     amat,
                     rhs,
                     lake_blocks,
                     dt,
                     self._lake.dfds(self._entries, kk, lake_blocks),
-                    nnode,
-                    transient=lake_storage,
+                    amat.shape[0],
+                    transient=is_transient,
                 )
 
             # the reach rows sit outside the lake rows, so they are added to
@@ -824,7 +850,6 @@ class PerfMeas:
             start = datetime.now()
             self.logger.logger.info("Solving for lambda")
 
-            is_newton = hdf[sol_key].attrs["is_newton"]
             self.logger.logger.debug(f"Newton-Raphson: {is_newton}")
 
             if linear_solver is None:
@@ -1058,8 +1083,20 @@ class PerfMeas:
                 # split the lake stages off and carry their storage back to the
                 # previous time step, as drhsdh does for the aquifer
                 lamb = self._lake.split(
-                    lamb, lake_blocks, dt, nnode, carry_back=lake_carry_back
+                    lamb, lake_blocks, dt, nsln, carry_back=carry_back
                 )
+            if self._maw.rows:
+                # the well rows are the innermost, being MODFLOW's own, and the
+                # well carries its storage back the way the aquifer does
+                lamb = self._maw.split(
+                    lamb,
+                    maw_blocks,
+                    dt,
+                    nnode,
+                    carry_back=carry_back,
+                )
+            elif nsln != nnode:
+                lamb = lamb[:nnode]
 
             if np.any(np.isnan(lamb)):
                 self.logger.logger.warning(
@@ -1074,7 +1111,6 @@ class PerfMeas:
                     + f"{(datetime.now() - start).total_seconds()} seconds"
                 )
             )
-            is_newton = hdf[sol_key].attrs["is_newton"]
 
             # zero out the adj state for chd nodes
             chd_nodelist = []

--- a/mf6adj/pm.py
+++ b/mf6adj/pm.py
@@ -650,6 +650,9 @@ class PerfMeas:
 
         comp_welq_sens = np.zeros(nnodes)
         comp_rch_sens = np.zeros((nnodes))
+        # a well rate is given per well and a connection conductance per
+        # connection, so neither maps onto the grid the way a boundary does
+        comp_maw_results = {}
 
         # A lake stage is a dependent variable, so the system is bordered with
         # the lake water balance. nnodes is a one-element array, so keep a
@@ -1086,6 +1089,24 @@ class PerfMeas:
                     lamb, lake_blocks, dt, nsln, carry_back=carry_back
                 )
             if self._maw.rows:
+                # the rate and conductance terms need the well rows, so they
+                # are taken before those rows come off
+                maw_sens = self._maw.sensitivities(
+                    lamb, head, maw_blocks, self._entries, kk
+                )
+                for pname, values in maw_sens.items():
+                    data[pname] = values
+                    totals = comp_maw_results.setdefault(
+                        pname,
+                        {
+                            "well": values["well"],
+                            "node": values["node"],
+                            "rate": np.zeros_like(values["rate"]),
+                            "cond": np.zeros_like(values["cond"]),
+                        },
+                    )
+                    totals["rate"] += values["rate"] * w
+                    totals["cond"] += values["cond"] * w
                 # the well rows are the innermost, being MODFLOW's own, and the
                 # well carries its storage back the way the aquifer does
                 lamb = self._maw.split(
@@ -1313,6 +1334,9 @@ class PerfMeas:
                 comp_sy_sens /= wsum
             for name in comp_bnd_results:
                 comp_bnd_results[name] /= wsum
+            for totals in comp_maw_results.values():
+                totals["rate"] /= wsum
+                totals["cond"] /= wsum
         data = {}
         data["k11"] = comp_k_sens
         data["k33"] = comp_k33_sens
@@ -1324,6 +1348,10 @@ class PerfMeas:
         data["rch6_recharge"] = comp_rch_sens
 
         for name, vals in comp_bnd_results.items():
+            data[name] = vals
+        # the hdf writer maps a vector onto the grid, and leaves a nested
+        # dictionary alone, which is what these are not shaped for
+        for name, vals in comp_maw_results.items():
             data[name] = vals
         self.logger.logger.info("Writing composite sensitivities")
         _write_group_to_hdf(

--- a/mf6adj/utils/utils_modflow.py
+++ b/mf6adj/utils/utils_modflow.py
@@ -16,6 +16,7 @@ SUPPORTED_PACKAGE_TYPES = (
     "drn6",
     "sfr6",
     "lak6",
+    "maw6",
     "rch6",
     "evt6",
 )
@@ -25,7 +26,6 @@ SUPPORTED_PACKAGE_TYPES = (
 # exchange is in the flow matrix, but the package itself has none.
 UNSUPPORTED_STRESS_TYPES = (
     "uzf6",
-    "maw6",
     "csub6",
     "api6",
     "mvr6",


### PR DESCRIPTION
A performance measure can now name a maw6 package, and a model carrying one is no longer refused. A multi-aquifer well head is solved with the flow equations, so the well equation is already a row of the matrix; what is formed here is the right-hand side of those rows and the well storage carried between time steps. The measure carries the conductance derivative as well as the head difference, without which the sensitivity is out by 9 to 12 percent for a specified-head well and by 300 to 700 percent for a specified-rate one.

The sensitivity to the rate a well is given and to the conductance of each connection is also reported. Both belong to a well or a connection rather than to a cell, so they are written under the name of the package rather than mapped onto the grid.

Adds a chapter to the supplemental technical information covering the terms and what is not carried.

Rebased onto main now that #107 has merged.

Refs #78, which the skipped maw6 test pointed at; the issue itself was closed with the lake and streamflow routing work.
