### PR TITLE
ci: leave the largest model out of the second python version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,14 +77,17 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest] 
         environment: [default]
+        task: [autotest-base]
         run-type: [std]
         test-path: ["."]
-        # the second python version is tested on one platform. What it can
-        # catch is a change in the language or in a dependency built against
-        # it, and neither is particular to an operating system.
+        # the second python version is tested on one platform, and without the
+        # tests marked slow. What it can catch is a change in the language or
+        # in a dependency built against it; neither is particular to an
+        # operating system, and neither needs the largest model to show.
         include:
           - os: ubuntu-latest
             environment: py312
+            task: autotest-quick
             run-type: std
             test-path: "."
     defaults:
@@ -119,7 +122,7 @@ jobs:
 
     - name: Autotest ${{ matrix.os }}-${{ matrix.environment }}
       run: |
-        pixi run -e ${{ matrix.environment }} autotest-base 
+        pixi run -e ${{ matrix.environment }} ${{ matrix.task }} 
 
     - name: Test notebooks ${{ matrix.os }}-${{ matrix.environment }}
       run: |

--- a/autotest/test_sagehen.py
+++ b/autotest/test_sagehen.py
@@ -13,6 +13,7 @@ matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
+import pytest
 from matplotlib.backends.backend_pdf import PdfPages
 
 try:
@@ -24,6 +25,7 @@ except ImportError:
 mf6_bin, lib_name = mf6adj.get_conda_mf6_paths()
 
 
+@pytest.mark.slow
 def test_sagehen():
     prep = True
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -105,6 +105,11 @@ install-gridgen = {cmd = "get-modflow --subset gridgen :python"}
 # test
 autotest = { cmd = "pixi run autotest-base; pixi run autotest-notebooks" }
 autotest-base = { cmd = "pixi run clean-tests; pytest -v -n=auto --durations=0 --cov=mf6adj --cov-report=xml --keep-failed .failed", cwd = "autotest" }
+# Everything but the tests marked slow. What a second python version catches is
+# a change in the language or in a dependency built against it, and the largest
+# model is not where that shows; on 3.12 it ran for an hour on its own, against
+# ten minutes for the rest of the suite.
+autotest-quick = { cmd = "pixi run clean-tests; pytest -v -n=auto -m 'not slow' --durations=0 --cov=mf6adj --cov-report=xml --keep-failed .failed", cwd = "autotest" }
 autotest-notebooks = { cmd = "pytest -v -n=auto --durations=0 --nbmake --nbmake-timeout=3000", cwd = "examples" }
 clean-notebooks = { cmd = "python clear_output_all.py", cwd = "examples" }
 clean-tests = { cmd = "rm -rf *_test", cwd = "autotest" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,6 +136,11 @@ ignore = [
     "RUF017", # quadratic-list-summation
 ]
 
+[tool.pytest.ini_options]
+markers = [
+    "slow: a test whose model is large enough that its runtime is the reason to skip it, never its coverage",
+]
+
 [tool.codespell]
 skip = './original_scripts/*,./autotest/**,./examples/clear_output_all.py,./examples/.ipynb_checkpoints/**,./examples/__pycache__/**,./examples/ex-gwf-zaidel/**,./examples/freyberg/**,./examples/sanpedro/**,./examples/synthdewater/**,./examples/synthdewater_working/**,./examples/xd_box_chd_ana/**,./examples/xd_box_chd_ana_working/**,./_build/**,./docs/_build/**,*.bst,*.pdf,*.log'
 ignore-words-list = [


### PR DESCRIPTION
The 3.12 job added in #110 ran 1h13m against 26m for the same suite on 3.11, and `test_sagehen` accounted for 56 of those minutes on its own (4,044s against 648s). That leaves it close to the two-hour job timeout, near enough that a slower runner would turn the build red for a reason unrelated to the change under test.

`test_sagehen` is now marked `slow`, and the 3.12 job runs `autotest-quick`, which is everything else. Every other test still runs under both versions. The marker is registered in `pyproject.toml` rather than the test being deselected by name, so the next test kept out for its runtime says so where it is defined.

Verified locally: 144 pass in 2m05s with the marker deselected, against 3m40s for the full suite, and the marker deselects exactly one test.

Why 3.12 is slow on that model is left open. The two tests that account for it are the two largest, which points at the numerical libraries rather than the tests: the 3.12 environment resolves numpy 2.5.2 where 3.11 has 2.4.6.