### PR TITLE
fix(npf): carry a horizontal flow barrier into the conductivity sensitivity

### DIFF
--- a/autotest/test_hfb.py
+++ b/autotest/test_hfb.py
@@ -1,0 +1,282 @@
+"""
+Tests for the horizontal flow barrier terms of the adjoint solution.
+
+A barrier adds no equations and exchanges no water. It changes the conductance
+of the connections it sits on, and MODFLOW writes that changed conductance into
+the array the flow equations are assembled from. A sensitivity to hydraulic
+conductivity is the derivative of that conductance, so it has to carry the
+barrier; formed without it, the sensitivity answers for a connection the model
+does not have.
+
+The barrier is given as a hydraulic characteristic. A positive one puts a
+barrier of that conductance in series with the connection, which always lowers
+it. A value of zero or less is read as a multiplier on the conductance instead,
+which lowers it, raises it, or closes the connection entirely depending on the
+magnitude. The two forms have different derivatives.
+
+Cases:
+  - test_horizontal_barrier   : the sensitivity to k11 at a cell beside a
+                                horizontal barrier matches a finite-difference
+                                derivative, and a cell with no barrier is
+                                unaffected.
+  - test_vertical_barrier     : the same for k33 across a barrier on a vertical
+                                connection.
+  - test_multiplier_form      : the same for a hydraulic characteristic given
+                                as a multiplier, where it lowers the
+                                conductance, raises it, and closes it.
+  - test_factor_follows_the_form : a barrier in series always lowers the
+                                conductance, and a multiplier does whatever it
+                                says, including raising it.
+  - test_barrier_matters      : dropping the barrier from the derivative moves
+                                the answer, so the tests above are testing it.
+  - test_no_barrier_unchanged : a model with no barrier writes no factor and
+                                reports what it did before.
+  - test_factor_is_one_away_from_a_barrier : the factor is one on every
+                                connection a barrier does not sit on.
+"""
+
+import pathlib as pl
+import shutil
+import sys
+
+import flopy
+import h5py
+import numpy as np
+import pytest
+
+try:
+    import mf6adj
+except ImportError:
+    sys.path.insert(0, str(pl.Path("../").resolve()))
+    import mf6adj
+
+mf6_bin, lib_name = mf6adj.get_conda_mf6_paths()
+
+NAME = "hfb"
+NLAY, NROW, NCOL = 2, 5, 5
+TOP, BOTM = 10.0, [0.0, -10.0]
+K, K33 = 10.0, 1.0
+OBS = (0, 2, 3)
+# the vertical case is driven between layers, so it is watched below the barrier
+VERTICAL_OBS = (1, 2, 3)
+# a cell on the upstream side of the line of horizontal barriers
+HORIZONTAL_CELL = (0, 2, 1)
+# a cell above a vertical barrier
+VERTICAL_CELL = (0, 2, 2)
+# layer 1 carries no horizontal barrier
+AWAY_CELL = (1, 2, 2)
+
+
+def _build(
+    ws, barrier="horizontal", hydchr=1.0e-3, kcell=None, kmult=1.0, k33cell=None
+):
+    """A confined model with constant heads at each end and one line of barriers."""
+    ws = pl.Path(ws)
+    if ws.exists():
+        shutil.rmtree(ws)
+    ws.mkdir(parents=True)
+    k = np.full((NLAY, NROW, NCOL), K)
+    k33 = np.full((NLAY, NROW, NCOL), K33)
+    if kcell is not None:
+        k[kcell] *= kmult
+    if k33cell is not None:
+        k33[k33cell] *= kmult
+    sim = flopy.mf6.MFSimulation(sim_name=NAME, sim_ws=str(ws), exe_name=mf6_bin)
+    flopy.mf6.ModflowTdis(sim, nper=1, perioddata=[(1.0, 1, 1.0)])
+    flopy.mf6.ModflowIms(
+        sim, complexity="simple", outer_dvclose=1e-11, inner_dvclose=1e-12
+    )
+    gwf = flopy.mf6.ModflowGwf(sim, modelname=NAME, save_flows=True)
+    flopy.mf6.ModflowGwfdis(
+        gwf, nlay=NLAY, nrow=NROW, ncol=NCOL, delr=10.0, delc=10.0, top=TOP, botm=BOTM
+    )
+    flopy.mf6.ModflowGwfic(gwf, strt=5.0)
+    # confined, so MODFLOW folds the barrier into the stored conductance
+    flopy.mf6.ModflowGwfnpf(gwf, icelltype=0, k=k, k33=k33)
+    if barrier == "vertical":
+        # in at the top on one side and out at the bottom on the other, so the
+        # water has to cross the connections the barriers sit on
+        chd = [[(0, i, 0), 6.0] for i in range(NROW)]
+        chd += [[(1, i, NCOL - 1), 4.0] for i in range(NROW)]
+    else:
+        chd = [[(0, i, 0), 6.0] for i in range(NROW)]
+        chd += [[(0, i, NCOL - 1), 4.0] for i in range(NROW)]
+    flopy.mf6.ModflowGwfchd(gwf, stress_period_data=chd, pname="chd-1")
+    if barrier == "horizontal":
+        spd = [[(0, i, 1), (0, i, 2), hydchr] for i in range(NROW)]
+    elif barrier == "vertical":
+        spd = [[(0, i, 2), (1, i, 2), hydchr] for i in range(NROW)]
+    else:
+        spd = None
+    if spd is not None:
+        flopy.mf6.ModflowGwfhfb(gwf, stress_period_data=spd, pname="hfb-1")
+    flopy.mf6.ModflowGwfoc(
+        gwf, head_filerecord=f"{NAME}.hds", saverecord=[("HEAD", "ALL")]
+    )
+    sim.write_simulation(silent=True)
+    success, buff = sim.run_simulation(silent=True)
+    assert success, "\n".join(buff[-20:])
+    return ws
+
+
+def _head(ws, obs=OBS):
+    return float(flopy.utils.HeadFile(pl.Path(ws) / f"{NAME}.hds").get_data()[obs])
+
+
+def _composite(ws, obs=OBS):
+    """Solve the adjoint for a head measure and return the composite results."""
+    ws = pl.Path(ws)
+    k, i, j = obs
+    with open(ws / "pm.dat", "w") as f:
+        f.write("begin performance_measure obs\n")
+        f.write(f"  1 1 {k + 1} {i + 1} {j + 1} head direct 1.0 -1.0e+30\n")
+        f.write("end performance_measure\n\n")
+    adj = mf6adj.Mf6Adj(
+        "pm.dat", lib_name, logging_level="ERROR", working_directory=str(ws)
+    )
+    adj.solve_forward_model(hdf5_name="fwd.hd5")
+    adj.solve_adjoint()
+    adj.finalize()
+    with h5py.File(ws / "adjoint_solution_obs.hd5", "r") as hf:
+        return {key: hf["composite"][key][:] for key in hf["composite"]}
+
+
+def _finite_difference(tmpdir, cell, vertical=False, obs=OBS, **kwargs):
+    """A central difference of the observed head with respect to K at one cell."""
+    d = 0.001
+    key = "k33cell" if vertical else "kcell"
+    base = K33 if vertical else K
+    plus = _build(tmpdir / "plus", **{key: cell}, kmult=1 + d, **kwargs)
+    minus = _build(tmpdir / "minus", **{key: cell}, kmult=1 - d, **kwargs)
+    return (_head(plus, obs) - _head(minus, obs)) / (2.0 * d * base)
+
+
+def test_horizontal_barrier(function_tmpdir):
+    """A cell beside a horizontal barrier matches a finite-difference derivative."""
+    composite = _composite(_build(function_tmpdir / "base"))
+
+    for label, cell in (("barrier", HORIZONTAL_CELL), ("away", AWAY_CELL)):
+        fd = _finite_difference(function_tmpdir, cell)
+        assert abs(fd) > 1.0e-8, f"{label} cell has no sensitivity to test"
+        assert composite["k11"][cell] == pytest.approx(fd, rel=1.0e-3), label
+
+
+def test_vertical_barrier(function_tmpdir):
+    """A barrier on a vertical connection is carried into the k33 sensitivity."""
+    composite = _composite(
+        _build(function_tmpdir / "base", barrier="vertical"), obs=VERTICAL_OBS
+    )
+
+    fd = _finite_difference(
+        function_tmpdir,
+        VERTICAL_CELL,
+        vertical=True,
+        obs=VERTICAL_OBS,
+        barrier="vertical",
+    )
+    assert abs(fd) > 1.0e-10, "the vertical connection has no sensitivity to test"
+    assert composite["k33"][VERTICAL_CELL] == pytest.approx(fd, rel=1.0e-3)
+
+
+@pytest.mark.parametrize(
+    "hydchr", [-0.01, -2.0, 0.0], ids=["reduces", "raises", "closes"]
+)
+def test_multiplier_form(function_tmpdir, hydchr):
+    """A hydraulic characteristic of zero or less multiplies the conductance.
+
+    The multiplier is not bounded by one, so this form can raise the
+    conductance of a connection as well as lower it, and a value of zero closes
+    the connection entirely. The derivative of a multiplier is not the
+    derivative of a barrier in series, so the two forms cannot share one
+    expression.
+    """
+    composite = _composite(_build(function_tmpdir / "base", hydchr=hydchr))
+
+    fd = _finite_difference(function_tmpdir, HORIZONTAL_CELL, hydchr=hydchr)
+    assert composite["k11"][HORIZONTAL_CELL] == pytest.approx(
+        fd, rel=1.0e-3, abs=1.0e-12
+    )
+
+
+@pytest.mark.parametrize(
+    "hydchr,expected", [(1.0e-3, "below"), (-2.0, "above"), (0.0, "zero")]
+)
+def test_factor_follows_the_form(function_tmpdir, hydchr, expected):
+    """A barrier does not have to lower the conductance of what it sits on.
+
+    In series it always does, because two conductances in series carry less
+    than either. As a multiplier it does whatever the multiplier says, so a
+    magnitude above one raises the conductance and the derivative with it.
+    """
+    ws = _build(function_tmpdir / "base", hydchr=hydchr)
+    _composite(ws)
+
+    with h5py.File(ws / "fwd.hd5", "r") as hf:
+        factor = hf["solution_kper:00000_kstp:00000"]["hfb_factor"][:]
+    scaled = factor[factor != 1.0]
+
+    if expected == "below":
+        assert (scaled < 1.0).all() and (scaled > 0.0).all()
+    elif expected == "above":
+        # the multiplier is applied once, not squared, so it is the factor
+        assert scaled == pytest.approx(-hydchr)
+        assert (scaled > 1.0).all()
+    else:
+        assert scaled == pytest.approx(0.0)
+
+
+def test_barrier_matters(function_tmpdir):
+    """Dropping the barrier from the derivative moves the answer a long way."""
+    from mf6adj.packages import npf
+
+    base = _build(function_tmpdir / "base")
+    fd = _finite_difference(function_tmpdir, HORIZONTAL_CELL)
+
+    original = npf.lam_dresdk_h
+
+    def without_barrier(*args, **kwargs):
+        kwargs["hfb_factor"] = None
+        return original(*args, **kwargs)
+
+    npf.lam_dresdk_h = without_barrier
+    try:
+        dropped = _composite(base)["k11"][HORIZONTAL_CELL]
+    finally:
+        npf.lam_dresdk_h = original
+
+    assert abs(dropped - fd) > 10.0 * abs(fd), (
+        "the barrier made no difference to the derivative, so this model does "
+        "not exercise it"
+    )
+
+
+def test_no_barrier_unchanged(function_tmpdir):
+    """A model with no barrier writes no factor and reports what it did before."""
+    ws = _build(function_tmpdir / "base", barrier=None)
+    composite = _composite(ws)
+
+    with h5py.File(ws / "fwd.hd5", "r") as hf:
+        step = hf["solution_kper:00000_kstp:00000"]
+        assert not step.attrs["has_hfb"]
+        assert "hfb_factor" not in step
+
+    for cell in (HORIZONTAL_CELL, AWAY_CELL):
+        fd = _finite_difference(function_tmpdir, cell, barrier=None)
+        assert composite["k11"][cell] == pytest.approx(fd, rel=1.0e-3)
+
+
+def test_factor_is_one_away_from_a_barrier(function_tmpdir):
+    """Only the connections a barrier sits on are scaled."""
+    ws = _build(function_tmpdir / "base")
+    _composite(ws)
+
+    with h5py.File(ws / "fwd.hd5", "r") as hf:
+        step = hf["solution_kper:00000_kstp:00000"]
+        assert step.attrs["has_hfb"]
+        factor = step["hfb_factor"][:]
+
+    scaled = factor != 1.0
+    assert scaled.sum() == NROW, "one connection per barrier should be scaled"
+    # the barrier is strong, so what it leaves is a small fraction of what the
+    # connection carried without it
+    assert (factor[scaled] < 1.0e-4).all()

--- a/docs/SuppInfo/Makefile
+++ b/docs/SuppInfo/Makefile
@@ -11,7 +11,7 @@ LATEX = pdflatex -interaction=nonstopmode -halt-on-error
 all: $(DOC).pdf
 
 $(DOC).pdf: $(DOC).tex body.tex introduction.tex instantaneous.tex \
-            storage.tex lake.tex sfr.tex maw.tex references.bib \
+            storage.tex lake.tex sfr.tex maw.tex hfb.tex references.bib \
             Figures/sfr-capture.pdf Figures/lake-capture.pdf
 	$(LATEX) $(DOC)
 	-bibtex $(DOC)

--- a/docs/SuppInfo/body.tex
+++ b/docs/SuppInfo/body.tex
@@ -25,3 +25,7 @@
 \chapter{Multi-Aquifer Well Package}
 \label{ch:maw}
 \input{maw.tex}
+
+\chapter{Horizontal Flow Barrier Package}
+\label{ch:hfb}
+\input{hfb.tex}

--- a/docs/SuppInfo/hfb.tex
+++ b/docs/SuppInfo/hfb.tex
@@ -1,0 +1,77 @@
+A horizontal flow barrier represents a feature too thin to discretize, a fault gouge or a slurry wall, by changing the conductance between two cells that are otherwise neighbors. The Horizontal Flow Barrier (HFB) Package adds no equations and exchanges no water, so it does not need the treatment Chapters~\ref{ch:lake} to \ref{ch:maw} give the advanced packages. It nonetheless changes a sensitivity the adjoint reports, because the quantity it alters is the one a conductivity sensitivity is the derivative of.
+
+\section*{A barrier inside the conductance}
+
+\mf{} does not hold the barrier apart from the flow equations. It replaces the conductance of the connection the barrier sits on, in the array the equations are assembled from, with the two in series,
+
+\begin{equation}
+	\label{eqn:hfb-series}
+	C = \frac{C_{0} \, C_{b}}{C_{0} + C_{b}}, \qquad C_{b} = c_{h} A,
+\end{equation}
+
+\noindent where $C_{0}$ is the conductance the connection has without the barrier (L$^{2}$T$^{-1}$), $C_{b}$ is the conductance of the barrier itself (L$^{2}$T$^{-1}$), $c_{h}$ is the hydraulic characteristic the barrier is given (T$^{-1}$), and $A$ is the area of the shared face (L$^{2}$).
+
+A hydraulic characteristic of zero or less means something else. \mf{} reads it as a multiplier on the conductance,
+
+\begin{equation}
+	\label{eqn:hfb-multiplier}
+	C = -c_{h} C_{0},
+\end{equation}
+
+\noindent and the two forms do not have the same derivative, so neither can stand for both.
+
+The two also differ in what they can do. Two conductances in series carry less than either, so equation~\ref{eqn:hfb-series} always lowers the conductance of the connection it sits on. Nothing bounds a multiplier by one, so equation~\ref{eqn:hfb-multiplier} lowers the conductance for $-c_{h}$ below one, raises it above one, and closes the connection at $c_{h}$ of zero. A barrier is named for the case it was written for, and is not restricted to it.
+
+\section*{What it does to a conductivity sensitivity}
+
+The sensitivity of a performance measure to hydraulic conductivity is formed from the derivative of the conductance of each connection with respect to the conductivity of the cells it joins. That derivative belongs to the conductance the model used, which is equation~\ref{eqn:hfb-series} and not $C_{0}$. Differentiating it,
+
+\begin{equation}
+	\label{eqn:hfb-derivative}
+	\frac{\partial C}{\partial C_{0}} =
+	\left( \frac{C_{b}}{C_{0} + C_{b}} \right)^{2} =
+	\left( \frac{C}{C_{0}} \right)^{2},
+\end{equation}
+
+\noindent for the series form, and $C / C_{0}$ without the square for the multiplier of equation~\ref{eqn:hfb-multiplier}. Each is the ratio of the conductance \mf{} arrived at to the one it started from, so neither the face area nor the geometry behind it is formed again in the adjoint, and a change in how \mf{} computes them does not reach the sensitivity.
+
+The factor is one where no barrier sits. It is below one wherever a barrier is in series, and takes whatever value the multiplier gives for the other form, so it is not always a reduction. Leaving it out does not perturb a sensitivity slightly; it reports the sensitivity of a connection the model does not have.
+
+The same factor covers a barrier on a vertical connection, which enters the specific-storage-free conductance between two layers in the same way and scales the derivative with respect to vertical conductivity rather than horizontal.
+
+\section*{Verification}
+
+A confined model two layers deep and 5 cells by 5 cells was given constant heads along two opposite edges and one line of barriers across it, and the sensitivity of a head to the conductivity of a cell beside a barrier was compared with a central difference between two forward runs. The cases are a barrier in series on a horizontal connection, the same given as a multiplier that lowers the conductance and as one that raises it, and a barrier in series on a vertical connection, the last with the constant heads arranged to drive the flow between layers.
+
+\begin{table}[htb]
+	\centering
+	\caption{Sensitivity of a head to the hydraulic conductivity of a cell
+	beside a barrier, against a finite-difference derivative. The last column
+	holds the conductance the connection would have with no barrier, which is
+	what the derivative was formed from before.}
+	\label{tab:hfb}
+	\small
+	\begin{tabular}{llrrr}
+		\toprule
+		Connection & Form &
+		\shortstack[r]{Finite\\difference} &
+		\shortstack[r]{Barrier\\carried} &
+		\shortstack[r]{Barrier\\dropped} \\
+		\midrule
+		Horizontal & series               & $2.8911 \times 10^{-5}$ & $2.8911 \times 10^{-5}$ & $2.0064 \times 10^{-2}$ \\
+		Horizontal & multiplier, lowering & $2.3330 \times 10^{-4}$ & $2.3330 \times 10^{-4}$ & $1.9269 \times 10^{-2}$ \\
+		Horizontal & multiplier, raising  & $3.6572 \times 10^{-3}$ & $3.6572 \times 10^{-3}$ & $2.8957 \times 10^{-3}$ \\
+		Vertical   & series               & $7.8970 \times 10^{-7}$ & $7.8970 \times 10^{-7}$ & $8.0557 \times 10^{-3}$ \\
+		\bottomrule
+	\end{tabular}
+\end{table}
+
+The adjoint reproduces the finite-difference derivative to six significant figures in every case of table~\ref{tab:hfb}. Formed from the unbarriered conductance instead, the same sensitivity is out by a factor of 694 on the horizontal connection in series, 83 on the multiplier that lowers the conductance, and 10,201 on the vertical connection. The multiplier that raises it is the case that shows the error is not always an overstatement: there the sensitivity formed without the barrier is 21 percent too small. The error is confined to the cells a barrier touches: a cell with no barrier on any of its connections reproduces the finite difference either way, because the adjoint state is taken from the matrix \mf{} assembled and that matrix carries the barrier already.
+
+\section*{What is not carried}
+
+\mf{} folds the barrier into the stored conductance under the Newton-Raphson formulation, and where neither of the two cells converts between confined and unconfined. Everywhere else it applies the barrier once per iteration against the saturated thickness of that iteration, and leaves the stored conductance alone. The conductance the sensitivity is formed from then does not carry the barrier, and there is nothing in what \mf{} keeps to recover the factor from. That condition is reported, and it is the same condition Chapter~\ref{ch:formulation} describes for the transmissivity: under the standard formulation a conductance that follows the head is lagged rather than assembled.
+
+Sensitivity to the hydraulic characteristic itself is a separate quantity and is not formed. A barrier belongs to a connection rather than to a cell, so it would not map onto the grid the way a conductivity does.
+
+A model that uses the XT3D formulation is a further case. There the flow between two cells is not the two-point expression equation~\ref{eqn:hfb-series} modifies, and neither the barrier treatment of this chapter nor the conductivity sensitivity it corrects applies.

--- a/mf6adj/adj.py
+++ b/mf6adj/adj.py
@@ -18,7 +18,7 @@ from .advanced_packages import (
     maw_forward_terms,
     sfr_forward_terms,
 )
-from .packages import storage
+from .packages import hfb, storage
 from .packages.head_dependent import DRAIN_CORNER_TOL
 from .pm import PerfMeas, PerfMeasRecord
 from .utils.utils import _utils_cd
@@ -179,6 +179,7 @@ class Mf6Adj:
                     nrow=nrow, ncol=ncol, nlay=nlay
                 )
                 self._shape = (nlay, nrow, ncol)
+            self._warned_hfb = False
             self._performance_measures = []
             self._read_adj_file()
             self._gwf_package_types = list(SUPPORTED_PACKAGE_TYPES)
@@ -570,6 +571,7 @@ class Mf6Adj:
             has_sto = False
             if has_sto_iconvert(self._gwf):
                 has_sto = True
+            has_hfb = "hfb6" in self._gwf_package_dict
 
             sp_package_data = None
             head_dict = None
@@ -736,6 +738,30 @@ class Mf6Adj:
                     self._gwf.get_var_address("CONDSAT", self._gwf_name.upper(), "NPF")
                 )
                 data_dict["condsat"] = condsat
+
+                # A barrier is not a package the adjoint forms terms for. It
+                # changes the conductance of the connections it sits on, and
+                # the conductivity sensitivity is the derivative of that
+                # conductance, so what it does to that derivative travels with
+                # the step it belongs to. Barriers can be given again each
+                # stress period, so this is not fixed for the run.
+                if has_hfb:
+                    hfb_factor, nlagged = hfb.conductance_factor(
+                        self._gwf, self._gwf_name, condsat.shape[0]
+                    )
+                    data_dict["hfb_factor"] = hfb_factor
+                    if nlagged > 0 and not self._warned_hfb:
+                        self._warned_hfb = True
+                        self.logger.logger.warning(
+                            f"{nlagged} horizontal flow barriers sit on a "
+                            "connection where a cell converts between confined "
+                            "and unconfined, and the flow model did not use "
+                            "the Newton-Raphson formulation. MODFLOW applies "
+                            "those barriers once per iteration rather than "
+                            "carrying them in the conductance, so the "
+                            "hydraulic conductivity sensitivity does not "
+                            "account for them and is approximate."
+                        )
 
                 iss = self._gwf.get_value(
                     self._gwf.get_var_address("ISS", self._gwf_name.upper())
@@ -925,6 +951,7 @@ class Mf6Adj:
                     "kstp": kstp,
                     "is_newton": is_newton,
                     "has_sto": has_sto,
+                    "has_hfb": has_hfb,
                 }
                 _write_group_to_hdf(
                     fhd,

--- a/mf6adj/packages/hfb.py
+++ b/mf6adj/packages/hfb.py
@@ -1,0 +1,108 @@
+"""Horizontal flow barrier (HFB) terms for the adjoint solution.
+
+A barrier adds no equations and exchanges no water. What it does is change the
+conductance of the connections it sits on, and MODFLOW writes that changed
+conductance into the array the flow equations are assembled from rather than
+keeping it apart. A sensitivity to hydraulic conductivity is the derivative of
+that conductance, so it has to carry the barrier or it answers for a connection
+the model does not have.
+
+A barrier in series always lowers the conductance, because two conductances in
+series carry less than either. Given as a multiplier it does whatever the
+multiplier says, so it can raise the conductance as well, and a multiplier of
+zero closes the connection.
+
+MODFLOW keeps the conductance each connection had before the barrier was
+applied, which is what makes the derivative recoverable without forming the
+barrier again here.
+"""
+
+import numpy as np
+
+# MODFLOW names the package HFB in memory whatever the name file calls it, and
+# a model holds one
+MEMORY_PATH = "HFB"
+
+
+def conductance_factor(gwf, gwf_name: str, nconn: int) -> tuple[np.ndarray, int]:
+    """Return what a barrier does to the derivative of conductance with respect to K.
+
+    Writing `a` for the conductance a connection has without the barrier and
+    `c` for the conductance of the barrier itself, MODFLOW puts the two in
+    series, `cond = a c / (a + c)`, so
+
+        d(cond)/da = (c / (a + c))**2 = (cond / a)**2,
+
+    which is one where there is no barrier and, since two conductances in
+    series carry less than either, below one wherever a barrier sits.
+
+    A hydraulic characteristic of zero or less means something else: MODFLOW
+    reads it as a multiplier on the conductance, `cond = -a hydchr`, whose
+    derivative is `cond / a` without the square. Nothing bounds a multiplier by
+    one, so this form can raise the conductance and the derivative with it, and
+    a multiplier of zero closes the connection and leaves it no derivative at
+    all.
+
+    Both forms are the ratio of what MODFLOW ended up with to what it started
+    with, so neither the flow area nor the screen geometry is formed again
+    here, and a change to how MODFLOW computes them does not reach this.
+
+    Parameters
+    ----------
+    gwf : modflowapi.ModflowApi
+        MODFLOW 6 groundwater-flow instance.
+    gwf_name : str
+        Name of the groundwater-flow model.
+    nconn : int
+        Number of connections in the symmetric arrays, which is the length of
+        the conductance array the factor is applied alongside.
+
+    Returns
+    -------
+    tuple[ndarray, int]
+        The factor for every connection, one where no barrier sits, and the
+        number of barriers whose effect MODFLOW is not carrying in the
+        conductance and which are therefore not in the factor. The factor is
+        below one for a barrier in series and takes the multiplier itself for
+        the other form, which is not bounded by one.
+    """
+
+    def value(name, *components):
+        return gwf.get_value(gwf.get_var_address(name, *components)).copy()
+
+    factor = np.ones(int(nconn))
+    nhfb = int(value("NHFB", gwf_name, MEMORY_PATH)[0])
+    if nhfb == 0:
+        return factor, 0
+
+    # the arrays are sized for the most barriers the package may hold, which is
+    # not always how many it holds now
+    idxloc = value("IDXLOC", gwf_name, MEMORY_PATH)[:nhfb] - 1
+    hydchr = value("HYDCHR", gwf_name, MEMORY_PATH)[:nhfb]
+    csatsav = value("CSATSAV", gwf_name, MEMORY_PATH)[:nhfb]
+    noden = value("NODEN", gwf_name, MEMORY_PATH)[:nhfb] - 1
+    nodem = value("NODEM", gwf_name, MEMORY_PATH)[:nhfb] - 1
+
+    jas = value("JAS", gwf_name, "CON") - 1
+    condsat = value("CONDSAT", gwf_name, "NPF")
+    icelltype = value("ICELLTYPE", gwf_name, "NPF")
+    is_newton = int(value("INEWTON", gwf_name)[0]) != 0
+
+    # MODFLOW folds the barrier into the conductance under the Newton-Raphson
+    # formulation, and where neither cell converts between confined and
+    # unconfined. Everywhere else it applies the barrier once per iteration
+    # against the saturated thickness of the moment, and leaves the stored
+    # conductance alone, so there is nothing there to recover the factor from.
+    folded = is_newton | ((icelltype[noden] == 0) & (icelltype[nodem] == 0))
+
+    for ihfb in range(nhfb):
+        if not folded[ihfb]:
+            continue
+        unbarriered = float(csatsav[ihfb])
+        if unbarriered <= 0.0:
+            continue
+        iconn = int(jas[int(idxloc[ihfb])])
+        ratio = float(condsat[iconn]) / unbarriered
+        factor[iconn] = ratio * ratio if hydchr[ihfb] > 0.0 else ratio
+
+    return factor, int(nhfb - np.count_nonzero(folded))

--- a/mf6adj/packages/npf.py
+++ b/mf6adj/packages/npf.py
@@ -162,6 +162,7 @@ def lam_dresdk_h(
     icelltype,
     k11,
     k33,
+    hfb_factor=None,
 ) -> tuple[np.ndarray, np.ndarray]:
     """Return adjoint-weighted residual derivatives.
 
@@ -203,6 +204,10 @@ def lam_dresdk_h(
         Horizontal hydraulic conductivity array.
     k33 : ndarray
         Vertical hydraulic conductivity array.
+    hfb_factor : ndarray, optional
+        What a horizontal flow barrier does to the derivative of conductance,
+        one entry per connection. Omitted where the model holds no barrier,
+        which is the same as an array of ones.
 
     Returns
     -------
@@ -212,6 +217,13 @@ def lam_dresdk_h(
     """
     iac = np.array([ia[i + 1] - ia[i] for i in range(len(ia) - 1)])
     # array of number of connections per node (size nodes)
+
+    # A horizontal flow barrier changes the conductance of the connections it
+    # sits on, so it scales the derivative of that conductance too. A model
+    # with no barrier scales by one, which is formed once here rather than
+    # tested for on every connection below.
+    if hfb_factor is None:
+        hfb_factor = np.ones(hwva.shape[0])
 
     sat_mod = sat.copy()
     sat_mod[icelltype == 0] = 1.0
@@ -245,7 +257,12 @@ def lam_dresdk_h(
                     1.0,
                     1.0,
                 )
-                t2 = dconddk33 * (head[mnode] - head[node]) * (lamb[node] - lamb[mnode])
+                t2 = (
+                    dconddk33
+                    * hfb_factor[jj]
+                    * (head[mnode] - head[node])
+                    * (lamb[node] - lamb[mnode])
+                )
                 sum1 += t2
 
             else:
@@ -285,6 +302,7 @@ def lam_dresdk_h(
                 t1 = (
                     SF
                     * dconddk
+                    * hfb_factor[jj]
                     * (head[mnode] - head[node])
                     * (lamb[node] - lamb[mnode])
                 )

--- a/mf6adj/pm.py
+++ b/mf6adj/pm.py
@@ -634,6 +634,9 @@ class PerfMeas:
         comp_sy_sens = None
 
         has_sto = hdf[sol_keys[0]].attrs["has_sto"]
+        # written by solve_forward_model; a forward file from before the
+        # barrier was carried has neither the flag nor the array
+        has_hfb = bool(hdf[sol_keys[0]].attrs.get("has_hfb", False))
         if has_sto:
             comp_ss_sens = np.zeros(nnodes)
             comp_sy_sens = np.zeros(nnodes)
@@ -1164,6 +1167,11 @@ class PerfMeas:
                 icelltype,
                 hdf[sol_key]["k11"][:],
                 hdf[sol_key]["k33"][:],
+                hfb_factor=(
+                    hdf[sol_key]["hfb_factor"][:]
+                    if has_hfb and "hfb_factor" in hdf[sol_key]
+                    else None
+                ),
             )
 
             data["k11"] = k_sens


### PR DESCRIPTION
A model holding a horizontal flow barrier reported hydraulic conductivity sensitivities that were wrong at every cell a barrier touched, with nothing to say so.

MODFLOW does not keep the barrier apart from the flow equations; it replaces the conductance of the connection in the array they are assembled from. `npf.lam_dresdk_h` rebuilt the conductance from `k11`, `k33` and the grid and never read `condsat`, so the derivative belonged to a connection the model does not have. The adjoint state was never wrong, which is why a cell with no barrier on any of its connections was right all along.

The factor recovered is the ratio of the conductance MODFLOW arrived at to the one it started from, squared for a barrier in series and taken as it is for the multiplier form. MODFLOW saves the pre-barrier conductance in `CSATSAV`, so no geometry is formed again here.

A barrier does not have to lower the conductance of what it sits on. In series it always does; given as a multiplier it does whatever the multiplier says, and a magnitude above one raises it. Against a central difference:

| connection | form | finite difference | carried | dropped |
| --- | --- | --- | --- | --- |
| horizontal | series | 2.8911e-05 | 2.8911e-05 | 2.0064e-02 (694x) |
| horizontal | multiplier, lowering | 2.3330e-04 | 2.3330e-04 | 1.9269e-02 (83x) |
| horizontal | multiplier, raising | 3.6572e-03 | 3.6572e-03 | 2.8957e-03 (0.8x) |
| vertical | series | 7.8970e-07 | 7.8970e-07 | 8.0557e-03 (10,201x) |

The raising case is why the correction is not a matter of scale in one direction: there the sensitivity formed without the barrier is 21 percent too small rather than too large.

The barrier is carried where MODFLOW carries it, which is under the Newton-Raphson formulation and where neither cell converts between confined and unconfined. Everywhere else MODFLOW applies it once per iteration and leaves the stored conductance alone, leaving nothing to recover the factor from; that condition is reported rather than corrected.

Adds a chapter to the supplemental technical information. Sensitivity to the hydraulic characteristic itself is not formed here, and a model using XT3D is a separate matter, tracked in #113.

Closes #112.
