### PR TITLE
feat(hfb): report the sensitivity to a barrier's hydraulic characteristic

### DIFF
--- a/autotest/test_hfb.py
+++ b/autotest/test_hfb.py
@@ -27,6 +27,12 @@ Cases:
   - test_factor_follows_the_form : a barrier in series always lowers the
                                 conductance, and a multiplier does whatever it
                                 says, including raising it.
+  - test_hydchr_sensitivity   : the sensitivity to the hydraulic characteristic
+                                a barrier is given matches a finite-difference
+                                derivative, in series and as a multiplier, on a
+                                horizontal and a vertical connection.
+  - test_hydchr_not_reported_without_a_barrier : a model with no barrier
+                                reports no barrier sensitivity.
   - test_barrier_matters      : dropping the barrier from the derivative moves
                                 the answer, so the tests above are testing it.
   - test_no_barrier_unchanged : a model with no barrier writes no factor and
@@ -124,7 +130,12 @@ def _head(ws, obs=OBS):
 
 
 def _composite(ws, obs=OBS):
-    """Solve the adjoint for a head measure and return the composite results."""
+    """Solve the adjoint for a head measure and return the composite results.
+
+    A group in the composite, which a barrier sensitivity is, comes back as a
+    dictionary of its own; a barrier belongs to a connection rather than to a
+    cell, so it is not mapped onto the grid.
+    """
     ws = pl.Path(ws)
     k, i, j = obs
     with open(ws / "pm.dat", "w") as f:
@@ -138,7 +149,13 @@ def _composite(ws, obs=OBS):
     adj.solve_adjoint()
     adj.finalize()
     with h5py.File(ws / "adjoint_solution_obs.hd5", "r") as hf:
-        return {key: hf["composite"][key][:] for key in hf["composite"]}
+        composite = {}
+        for key, item in hf["composite"].items():
+            if isinstance(item, h5py.Group):
+                composite[key] = {k: v[:] for k, v in item.items()}
+            else:
+                composite[key] = item[:]
+        return composite
 
 
 def _finite_difference(tmpdir, cell, vertical=False, obs=OBS, **kwargs):
@@ -280,3 +297,43 @@ def test_factor_is_one_away_from_a_barrier(function_tmpdir):
     # the barrier is strong, so what it leaves is a small fraction of what the
     # connection carried without it
     assert (factor[scaled] < 1.0e-4).all()
+
+
+@pytest.mark.parametrize(
+    "hydchr,barrier,obs",
+    [
+        (1.0e-3, "horizontal", OBS),
+        (-0.01, "horizontal", OBS),
+        (-2.0, "horizontal", OBS),
+        (1.0e-3, "vertical", VERTICAL_OBS),
+    ],
+    ids=["series", "multiplier-lower", "multiplier-raise", "vertical"],
+)
+def test_hydchr_sensitivity(function_tmpdir, hydchr, barrier, obs):
+    """The sensitivity to a barrier matches a finite-difference derivative.
+
+    Every barrier in the line is given the same hydraulic characteristic, so
+    moving it moves all of them at once and the derivative to compare against
+    is the sum over the line.
+    """
+    composite = _composite(
+        _build(function_tmpdir / "base", barrier=barrier, hydchr=hydchr), obs=obs
+    )
+
+    step = abs(hydchr) * 1.0e-3
+    plus = _build(function_tmpdir / "plus", barrier=barrier, hydchr=hydchr + step)
+    minus = _build(function_tmpdir / "minus", barrier=barrier, hydchr=hydchr - step)
+    fd = (_head(plus, obs) - _head(minus, obs)) / (2.0 * step)
+
+    assert abs(fd) > 1.0e-6, "the barrier has no sensitivity to test"
+    assert composite["hfb"]["hydchr"].sum() == pytest.approx(fd, rel=1.0e-3)
+    # the barrier is named by the cells it lies between, since it belongs to
+    # the connection rather than to either of them
+    assert (composite["hfb"]["noden"] != composite["hfb"]["nodem"]).all()
+    assert composite["hfb"]["barrier"].shape[0] == NROW
+
+
+def test_hydchr_not_reported_without_a_barrier(function_tmpdir):
+    """A model with no barrier reports no barrier sensitivity."""
+    composite = _composite(_build(function_tmpdir / "base", barrier=None))
+    assert "hfb" not in composite

--- a/docs/SuppInfo/hfb.tex
+++ b/docs/SuppInfo/hfb.tex
@@ -68,10 +68,45 @@ A confined model two layers deep and 5 cells by 5 cells was given constant heads
 
 The adjoint reproduces the finite-difference derivative to six significant figures in every case of table~\ref{tab:hfb}. Formed from the unbarriered conductance instead, the same sensitivity is out by a factor of 694 on the horizontal connection in series, 83 on the multiplier that lowers the conductance, and 10,201 on the vertical connection. The multiplier that raises it is the case that shows the error is not always an overstatement: there the sensitivity formed without the barrier is 21 percent too small. The error is confined to the cells a barrier touches: a cell with no barrier on any of its connections reproduces the finite difference either way, because the adjoint state is taken from the matrix \mf{} assembled and that matrix carries the barrier already.
 
+\section*{Sensitivity to the barrier}
+
+The hydraulic characteristic is a term of the model, so a performance measure has a sensitivity to it. Differentiating equation~\ref{eqn:hfb-series} with respect to $c_{h}$ rather than $C_{0}$,
+
+\begin{equation}
+	\label{eqn:hfb-hydchr}
+	\frac{\partial C}{\partial c_{h}} =
+	\left( \frac{C}{C_{b}} \right)^{2} A =
+	\frac{C \left( C_{0} - C \right)}{c_{h} C_{0}},
+\end{equation}
+
+\noindent the second form of which carries no area, so it is written from the same two conductances the factor of equation~\ref{eqn:hfb-derivative} uses. A barrier weak enough to leave the connection alone has $C \rightarrow C_{b}$, and equation~\ref{eqn:hfb-hydchr} approaches the area of the face: a unit of hydraulic characteristic buys a unit of conductance for every unit of area it acts over. The derivative falls away as the barrier strengthens, because a strong barrier already sets the conductance and a little more of it changes little. For the multiplier of equation~\ref{eqn:hfb-multiplier} the derivative is $-C_{0}$, which does not depend on the multiplier at all.
+
+A barrier lies on a connection rather than in a cell, so its sensitivity does not map onto the grid the way a conductivity does. It is reported per barrier, with the two cells the barrier lies between, beside the grid-shaped results.
+
+Against a central difference on the same model, taking the sum over the line of barriers because they are given one characteristic between them, the adjoint reproduces the derivative to six significant figures in each of the four cases of table~\ref{tab:hfb-hydchr}.
+
+\begin{table}[htb]
+	\centering
+	\caption{Sensitivity of a head to the hydraulic characteristic of a line of
+	barriers, against a finite-difference derivative.}
+	\label{tab:hfb-hydchr}
+	\small
+	\begin{tabular}{llrr}
+		\toprule
+		Connection & Form &
+		\shortstack[r]{Finite\\difference} &
+		\shortstack[r]{Adjoint} \\
+		\midrule
+		Horizontal & series               & $1.41642$              & $1.41642$ \\
+		Horizontal & multiplier, lowering & $-1.35568$             & $-1.35568$ \\
+		Horizontal & multiplier, raising  & $-3.7543 \times 10^{-2}$ & $-3.7543 \times 10^{-2}$ \\
+		Vertical   & series               & $0.54098$              & $0.54098$ \\
+		\bottomrule
+	\end{tabular}
+\end{table}
+
 \section*{What is not carried}
 
 \mf{} folds the barrier into the stored conductance under the Newton-Raphson formulation, and where neither of the two cells converts between confined and unconfined. Everywhere else it applies the barrier once per iteration against the saturated thickness of that iteration, and leaves the stored conductance alone. The conductance the sensitivity is formed from then does not carry the barrier, and there is nothing in what \mf{} keeps to recover the factor from. That condition is reported, and it is the same condition Chapter~\ref{ch:formulation} describes for the transmissivity: under the standard formulation a conductance that follows the head is lagged rather than assembled.
-
-Sensitivity to the hydraulic characteristic itself is a separate quantity and is not formed. A barrier belongs to a connection rather than to a cell, so it would not map onto the grid the way a conductivity does.
 
 A model that uses the XT3D formulation is a further case. There the flow between two cells is not the two-point expression equation~\ref{eqn:hfb-series} modifies, and neither the barrier treatment of this chapter nor the conductivity sensitivity it corrects applies.

--- a/mf6adj/adj.py
+++ b/mf6adj/adj.py
@@ -746,10 +746,10 @@ class Mf6Adj:
                 # the step it belongs to. Barriers can be given again each
                 # stress period, so this is not fixed for the run.
                 if has_hfb:
-                    hfb_factor, nlagged = hfb.conductance_factor(
+                    hfb_terms, nlagged = hfb.forward_terms(
                         self._gwf, self._gwf_name, condsat.shape[0]
                     )
-                    data_dict["hfb_factor"] = hfb_factor
+                    data_dict.update(hfb_terms)
                     if nlagged > 0 and not self._warned_hfb:
                         self._warned_hfb = True
                         self.logger.logger.warning(
@@ -758,9 +758,10 @@ class Mf6Adj:
                             "and unconfined, and the flow model did not use "
                             "the Newton-Raphson formulation. MODFLOW applies "
                             "those barriers once per iteration rather than "
-                            "carrying them in the conductance, so the "
-                            "hydraulic conductivity sensitivity does not "
-                            "account for them and is approximate."
+                            "carrying them in the conductance, so neither "
+                            "the hydraulic conductivity sensitivity nor the "
+                            "sensitivity to the barrier itself accounts for "
+                            "them, and both are approximate."
                         )
 
                 iss = self._gwf.get_value(

--- a/mf6adj/packages/hfb.py
+++ b/mf6adj/packages/hfb.py
@@ -3,9 +3,12 @@
 A barrier adds no equations and exchanges no water. What it does is change the
 conductance of the connections it sits on, and MODFLOW writes that changed
 conductance into the array the flow equations are assembled from rather than
-keeping it apart. A sensitivity to hydraulic conductivity is the derivative of
-that conductance, so it has to carry the barrier or it answers for a connection
-the model does not have.
+keeping it apart. Two things follow from that.
+
+A sensitivity to hydraulic conductivity is the derivative of that conductance,
+so it has to carry the barrier or it answers for a connection the model does
+not have. And the barrier itself is a term of the model, so a measure has a
+sensitivity to the hydraulic characteristic it is given.
 
 A barrier in series always lowers the conductance, because two conductances in
 series carry less than either. Given as a multiplier it does whatever the
@@ -13,8 +16,9 @@ multiplier says, so it can raise the conductance as well, and a multiplier of
 zero closes the connection.
 
 MODFLOW keeps the conductance each connection had before the barrier was
-applied, which is what makes the derivative recoverable without forming the
-barrier again here.
+applied. Both derivatives below are ratios of what it ended up with to what it
+started from, so neither the flow area nor the geometry behind it is formed
+again here, and a change to how MODFLOW computes them does not reach either.
 """
 
 import numpy as np
@@ -24,28 +28,26 @@ import numpy as np
 MEMORY_PATH = "HFB"
 
 
-def conductance_factor(gwf, gwf_name: str, nconn: int) -> tuple[np.ndarray, int]:
-    """Return what a barrier does to the derivative of conductance with respect to K.
+def forward_terms(gwf, gwf_name: str, nconn: int) -> tuple[dict, int]:
+    """Return the barrier terms of a model for one time step.
 
-    Writing `a` for the conductance a connection has without the barrier and
-    `c` for the conductance of the barrier itself, MODFLOW puts the two in
-    series, `cond = a c / (a + c)`, so
+    Writing `a` for the conductance a connection has without the barrier, `c`
+    for the conductance of the barrier, and `h` for the hydraulic
+    characteristic it is given, MODFLOW puts the two in series where `h` is
+    positive, `cond = a c / (a + c)` with `c = h A` over the face area `A`. The
+    two derivatives that follow are
 
-        d(cond)/da = (c / (a + c))**2 = (cond / a)**2,
+        d(cond)/da = (cond / a)**2,
+        d(cond)/dh = cond (a - cond) / (h a),
 
-    which is one where there is no barrier and, since two conductances in
-    series carry less than either, below one wherever a barrier sits.
+    the second of which is the face area where the barrier is weak, and falls
+    away as it strengthens.
 
     A hydraulic characteristic of zero or less means something else: MODFLOW
-    reads it as a multiplier on the conductance, `cond = -a hydchr`, whose
-    derivative is `cond / a` without the square. Nothing bounds a multiplier by
-    one, so this form can raise the conductance and the derivative with it, and
-    a multiplier of zero closes the connection and leaves it no derivative at
-    all.
-
-    Both forms are the ratio of what MODFLOW ended up with to what it started
-    with, so neither the flow area nor the screen geometry is formed again
-    here, and a change to how MODFLOW computes them does not reach this.
+    reads it as a multiplier on the conductance, `cond = -a h`, whose
+    derivatives are `cond / a` and `-a`. Nothing bounds a multiplier by one, so
+    this form can raise the conductance, and a multiplier of zero closes the
+    connection.
 
     Parameters
     ----------
@@ -59,12 +61,12 @@ def conductance_factor(gwf, gwf_name: str, nconn: int) -> tuple[np.ndarray, int]
 
     Returns
     -------
-    tuple[ndarray, int]
-        The factor for every connection, one where no barrier sits, and the
-        number of barriers whose effect MODFLOW is not carrying in the
-        conductance and which are therefore not in the factor. The factor is
-        below one for a barrier in series and takes the multiplier itself for
-        the other form, which is not bounded by one.
+    tuple[dict, int]
+        The barrier terms, and the number of barriers whose effect MODFLOW is
+        not carrying in the conductance and which are therefore in neither
+        derivative. ``hfb_factor`` is one for every connection no barrier sits
+        on, and ``hfb_dconddhc`` is the derivative of the conductance with
+        respect to the hydraulic characteristic, one per barrier.
     """
 
     def value(name, *components):
@@ -73,7 +75,13 @@ def conductance_factor(gwf, gwf_name: str, nconn: int) -> tuple[np.ndarray, int]
     factor = np.ones(int(nconn))
     nhfb = int(value("NHFB", gwf_name, MEMORY_PATH)[0])
     if nhfb == 0:
-        return factor, 0
+        return {
+            "hfb_factor": factor,
+            "hfb_dconddhc": np.zeros(0),
+            "hfb_hydchr": np.zeros(0),
+            "hfb_noden": np.zeros(0, dtype=int),
+            "hfb_nodem": np.zeros(0, dtype=int),
+        }, 0
 
     # the arrays are sized for the most barriers the package may hold, which is
     # not always how many it holds now
@@ -92,9 +100,11 @@ def conductance_factor(gwf, gwf_name: str, nconn: int) -> tuple[np.ndarray, int]
     # formulation, and where neither cell converts between confined and
     # unconfined. Everywhere else it applies the barrier once per iteration
     # against the saturated thickness of the moment, and leaves the stored
-    # conductance alone, so there is nothing there to recover the factor from.
+    # conductance alone, so there is nothing there to recover either
+    # derivative from.
     folded = is_newton | ((icelltype[noden] == 0) & (icelltype[nodem] == 0))
 
+    dconddhc = np.zeros(nhfb)
     for ihfb in range(nhfb):
         if not folded[ihfb]:
             continue
@@ -102,7 +112,51 @@ def conductance_factor(gwf, gwf_name: str, nconn: int) -> tuple[np.ndarray, int]
         if unbarriered <= 0.0:
             continue
         iconn = int(jas[int(idxloc[ihfb])])
-        ratio = float(condsat[iconn]) / unbarriered
-        factor[iconn] = ratio * ratio if hydchr[ihfb] > 0.0 else ratio
+        barriered = float(condsat[iconn])
+        ratio = barriered / unbarriered
+        if hydchr[ihfb] > 0.0:
+            factor[iconn] = ratio * ratio
+            dconddhc[ihfb] = (
+                barriered * (unbarriered - barriered) / (hydchr[ihfb] * unbarriered)
+            )
+        else:
+            factor[iconn] = ratio
+            dconddhc[ihfb] = -unbarriered
 
-    return factor, int(nhfb - np.count_nonzero(folded))
+    return {
+        "hfb_dconddhc": dconddhc,
+        "hfb_factor": factor,
+        "hfb_hydchr": hydchr,
+        "hfb_noden": noden,
+        "hfb_nodem": nodem,
+    }, int(nhfb - np.count_nonzero(folded))
+
+
+def sensitivity(dconddhc, noden, nodem, head, lamb) -> np.ndarray:
+    """Return the sensitivity of a measure to each hydraulic characteristic.
+
+    A barrier sits on one connection, so what it changes is the flow between
+    the two cells that connection joins, and the measure follows it through the
+    adjoint state of each. The form is the one the conductivity sensitivity
+    takes for a connection, with the derivative of the conductance with respect
+    to the hydraulic characteristic in place of the one with respect to
+    conductivity.
+
+    Parameters
+    ----------
+    dconddhc : ndarray
+        Derivative of the conductance with respect to the hydraulic
+        characteristic, one per barrier.
+    noden, nodem : ndarray
+        Zero-based nodes the barrier lies between.
+    head : ndarray
+        Simulated head for every node.
+    lamb : ndarray
+        Adjoint state for every node.
+
+    Returns
+    -------
+    ndarray
+        Sensitivity to the hydraulic characteristic of each barrier.
+    """
+    return dconddhc * (head[nodem] - head[noden]) * (lamb[noden] - lamb[nodem])

--- a/mf6adj/pm.py
+++ b/mf6adj/pm.py
@@ -22,7 +22,7 @@ from scipy.sparse.linalg import (
 )
 
 from .advanced_packages import LakeCoupling, MawCoupling, SfrCoupling
-from .packages import head_dependent, npf, recharge, well
+from .packages import head_dependent, hfb, npf, recharge, well
 from .packages.head_dependent import DRAIN_CORNER_TOL, drop_corner_entries
 from .utils.utils import SolverCallback
 from .utils.utils_fileio import _write_group_to_hdf
@@ -656,6 +656,9 @@ class PerfMeas:
         # a well rate is given per well and a connection conductance per
         # connection, so neither maps onto the grid the way a boundary does
         comp_maw_results = {}
+        # a barrier is given per barrier, and sits on a connection rather than
+        # in a cell, so it does not map onto the grid either
+        comp_hfb_sens = None
 
         # A lake stage is a dependent variable, so the system is bordered with
         # the lake water balance. nnodes is a one-element array, so keep a
@@ -1176,6 +1179,30 @@ class PerfMeas:
 
             data["k11"] = k_sens
             data["k33"] = k33_sens
+
+            if has_hfb and "hfb_dconddhc" in hdf[sol_key]:
+                noden = hdf[sol_key]["hfb_noden"][:]
+                hfb_sens = hfb.sensitivity(
+                    hdf[sol_key]["hfb_dconddhc"][:],
+                    noden,
+                    hdf[sol_key]["hfb_nodem"][:],
+                    head,
+                    lamb,
+                )
+                if comp_hfb_sens is None:
+                    comp_hfb_sens = {
+                        "barrier": np.arange(noden.shape[0]) + 1,
+                        "noden": noden + 1,
+                        "nodem": hdf[sol_key]["hfb_nodem"][:] + 1,
+                        "hydchr": np.zeros_like(hfb_sens),
+                    }
+                comp_hfb_sens["hydchr"] += hfb_sens * w
+                data["hfb"] = {
+                    "barrier": comp_hfb_sens["barrier"],
+                    "noden": comp_hfb_sens["noden"],
+                    "nodem": comp_hfb_sens["nodem"],
+                    "hydchr": hfb_sens,
+                }
             comp_k_sens += k_sens * w
             comp_k33_sens += k33_sens * w
             self.logger.logger.debug(
@@ -1348,6 +1375,8 @@ class PerfMeas:
                 totals["rate"] /= wsum
                 totals["head"] /= wsum
                 totals["cond"] /= wsum
+            if comp_hfb_sens is not None:
+                comp_hfb_sens["hydchr"] /= wsum
         data = {}
         data["k11"] = comp_k_sens
         data["k33"] = comp_k33_sens
@@ -1364,6 +1393,8 @@ class PerfMeas:
         # dictionary alone, which is what these are not shaped for
         for name, vals in comp_maw_results.items():
             data[name] = vals
+        if comp_hfb_sens is not None:
+            data["hfb"] = comp_hfb_sens
         self.logger.logger.info("Writing composite sensitivities")
         _write_group_to_hdf(
             adf,


### PR DESCRIPTION
The hydraulic characteristic a barrier is given is a term of the model, and a performance measure had no sensitivity to it. #114 corrected what a barrier does to the conductivity sensitivity; this reports the barrier itself.

Differentiating the conductance with respect to the characteristic rather than with respect to conductivity gives

```
dC/dc_h = C (C0 - C) / (c_h C0)     barrier in series
        = -C0                        multiplier form
```

with `C0` the conductance before the barrier, from `CSATSAV`. That form carries no flow area, so it is written from the same two conductances the factor in #114 already uses, and nothing here reproduces geometry MODFLOW formed. A barrier weak enough to leave the connection alone has a derivative equal to the area of the face, which is what a unit of characteristic buys per unit of area it acts over; the derivative falls away as the barrier strengthens, because a strong barrier already sets the conductance.

Against a central difference, taking the sum over the line of barriers since they are given one characteristic between them:

| connection | form | finite difference | adjoint |
| --- | --- | --- | --- |
| horizontal | series | 1.416425 | 1.416425 |
| horizontal | multiplier, lowering | -1.355675 | -1.355675 |
| horizontal | multiplier, raising | -3.7543e-02 | -3.7543e-02 |
| vertical | series | 0.540977 | 0.540977 |

A barrier lies on a connection rather than in a cell, so the sensitivity does not map onto the grid the way a conductivity does. It is reported per barrier with the two cells the barrier lies between, beside the grid-shaped results, as a multi-aquifer well rate is. A model with no barrier reports nothing.

The reads the two derivatives share are now made once, so the forward pass takes the barrier terms as one set the way it takes an advanced package's. The supplemental technical information chapter gains a section.

Where MODFLOW applies the barrier once per iteration rather than carrying it in the conductance, neither derivative accounts for it, and that condition is reported as before.

Refs #112.
