### PR TITLE
build: let a task that runs other tasks fail when one of them does

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -76,6 +76,11 @@ hatch-fancy-pypi-readme = "*"
 rtds-action = "*"
 
 [tasks]
+# A task that runs another with "pixi run" inside its own command line takes
+# the exit code of whatever ran last, so a failure in anything before that is
+# reported as success. Tasks that run other tasks therefore name them in
+# depends-on, which runs them in the order given, stops at the first failure,
+# and returns that failure.
 pre-commit-install = { cmd = "pre-commit install" }
 postinstall = "pip install --no-deps --disable-pip-version-check -e ."
 
@@ -90,25 +95,25 @@ update-flopy = { cmd = "python -m flopy.mf6.utils.generate_classes --ref develop
 
 # format
 format = { cmd = "pre-commit run --all-files" }
-format-all = { cmd = "pixi run clean-notebooks; pre-commit run --all-files" }
+format-all = { depends-on = ["clean-notebooks"], cmd = "pre-commit run --all-files" }
 check-lint = "ruff check ."
 check-format = "ruff format . --check"
 check-spelling = "codespell"
 fix-style = "ruff check . --fix; ruff format ."
 
 # install 
-install-executables = { cmd = "pixi run install-modflow; pixi run install-gridgen" }
+install-executables = { depends-on = ["install-modflow", "install-gridgen"] }
 install-modflow = {cmd = "get-modflow --repo modflow6-nightly-build :python"}
 install-gridgen = {cmd = "get-modflow --subset gridgen :python"}
 
 # test
-autotest = { cmd = "pixi run autotest-base; pixi run autotest-notebooks" }
-autotest-base = { cmd = "pixi run clean-tests; pytest -v -n=auto --durations=0 --cov=mf6adj --cov-report=xml --keep-failed .failed", cwd = "autotest" }
+autotest = { depends-on = ["autotest-base", "autotest-notebooks"] }
+autotest-base = { depends-on = ["clean-tests"], cmd = "pytest -v -n=auto --durations=0 --cov=mf6adj --cov-report=xml --keep-failed .failed", cwd = "autotest" }
 # Everything but the tests marked slow. What a second python version catches is
 # a change in the language or in a dependency built against it, and the largest
 # model is not where that shows; on 3.12 it ran for an hour on its own, against
 # ten minutes for the rest of the suite.
-autotest-quick = { cmd = "pixi run clean-tests; pytest -v -n=auto -m 'not slow' --durations=0 --cov=mf6adj --cov-report=xml --keep-failed .failed", cwd = "autotest" }
+autotest-quick = { depends-on = ["clean-tests"], cmd = "pytest -v -n=auto -m 'not slow' --durations=0 --cov=mf6adj --cov-report=xml --keep-failed .failed", cwd = "autotest" }
 autotest-notebooks = { cmd = "pytest -v -n=auto --durations=0 --nbmake --nbmake-timeout=3000", cwd = "examples" }
 clean-notebooks = { cmd = "python clear_output_all.py", cwd = "examples" }
 clean-tests = { cmd = "rm -rf *_test", cwd = "autotest" }
@@ -119,6 +124,6 @@ coverage-report = { cmd = "coverage report", cwd = "autotest"}
 # docs
 docs-install = { cmd = "pip install --no-deps --disable-pip-version-check -e '.[doc]'" }
 docs-apidoc = { cmd = "python scripts/sphinx_apidoc.py" }
-docs-build = { cmd = "pixi run docs-install; python scripts/sphinx_build.py" }
-docs-build-exec = { cmd = "pixi run docs-install; python scripts/sphinx_build.py --execute" }
+docs-build = { depends-on = ["docs-install"], cmd = "python scripts/sphinx_build.py" }
+docs-build-exec = { depends-on = ["docs-install"], cmd = "python scripts/sphinx_build.py --execute" }
 docs-clean = { cmd = "rm -rf docs/_build docs/source/_api docs/source/examples" }


### PR DESCRIPTION
A task whose command line ran another task with `pixi run` took the exit code of whatever ran last, so a failure in anything before that was reported as success.

`install-executables` ran the MODFLOW install and then the gridgen install. In #116 the MODFLOW download hit `HTTP Error 504: Gateway Time-out` against the release server, the step reported success on the strength of gridgen, and the whole suite then ran against an environment with no MODFLOW in it. That reached the pull request as 113 failing tests on a missing program rather than as a failed install.

`autotest` had the same shape and a worse consequence: it ran the test suite and then the notebooks, so a failing suite was reported as success whenever the notebooks passed.

Seven tasks named other tasks this way; all now use `depends-on`. Confirmed against the old form on this repository: a semicolon chain whose first task exits 3 returns 0 and runs the rest anyway, while `depends-on` returns 3 and stops. Ordering is preserved, so nothing runs concurrently that did not before.

Verified: every converted task still runs, the lock is untouched, and 156 tests pass.