### PR TITLE
chore: open the 1.4.0 development cycle

### DIFF
--- a/mf6adj/version.py
+++ b/mf6adj/version.py
@@ -1,4 +1,4 @@
 # mf6adj version file automatically created using
-# update_version.py on September 09, 2026 09:54:39
+# update_version.py on September 09, 2026 12:09:19
 
-__version__ = "1.3.0"
+__version__ = "1.4.0.dev0"


### PR DESCRIPTION
Sets the version to `1.4.0.dev0` now that 1.3.0 is released, so a build from `main` is not mistaken for the release.

Done as an ordinary change rather than through the release workflow. The workflow's `dev` bump computes the right version, but the rest of the prep job runs with it: it would write a changelog entry for a version with no pull requests behind it, push a `v1.4.0.dev0` branch, and open a pull request titled as a release. Opening a cycle is none of those. #75 opened the 1.3.0 cycle the same way.

`CITATION.cff` stays at 1.3.0, which is the version to cite; it moves when the next release is cut. That matches the 1.3.0 cycle, where the citation stayed at 1.2.0 throughout.