### PR TITLE
ci(release): make the dev bump open a cycle rather than half a release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,7 +115,16 @@ jobs:
           ")
           echo "current=$current" >> $GITHUB_OUTPUT
           echo "version=$new" >> $GITHUB_OUTPUT
-          echo "branch=v$new" >> $GITHUB_OUTPUT
+          # a dev bump opens the next cycle rather than releasing, and the
+          # job that drafts a release triggers on a merged v* branch, so this
+          # one is named so that it does not
+          if [ "${{ inputs.bump }}" = "dev" ]; then
+            echo "branch=open-$new-cycle" >> $GITHUB_OUTPUT
+            echo "cycle=true" >> $GITHUB_OUTPUT
+          else
+            echo "branch=v$new" >> $GITHUB_OUTPUT
+            echo "cycle=false" >> $GITHUB_OUTPUT
+          fi
           echo "$current -> $new"
 
       - name: Update version numbers
@@ -127,6 +136,9 @@ jobs:
           uv run python -c "import mf6adj; print(f'mf6adj version: {mf6adj.__version__}')"
 
       - name: Sync CITATION.cff
+        # the citation records the version to cite, which stays at the last
+        # release through a development cycle
+        if: ${{ steps.version.outputs.cycle != 'true' }}
         env:
           VERSION: ${{ steps.version.outputs.version }}
         run: |
@@ -146,6 +158,9 @@ jobs:
           git diff --stat CITATION.cff
 
       - name: Generate changelog
+        # a cycle is opened with nothing merged behind it, so an entry for it
+        # would be empty
+        if: ${{ steps.version.outputs.cycle != 'true' }}
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
@@ -185,8 +200,13 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git switch -c "${{ steps.version.outputs.branch }}"
-          git add mf6adj/version.py changelog/CHANGELOG.md CITATION.cff
-          git commit -m "bump version to ${{ steps.version.outputs.version }} [skip ci]"
+          if [ "${{ steps.version.outputs.cycle }}" = "true" ]; then
+            git add mf6adj/version.py
+            git commit -m "open the ${{ steps.version.outputs.version }} cycle [skip ci]"
+          else
+            git add mf6adj/version.py changelog/CHANGELOG.md CITATION.cff
+            git commit -m "bump version to ${{ steps.version.outputs.version }} [skip ci]"
+          fi
           git push origin "${{ steps.version.outputs.branch }}"
 
       - name: Draft pull request
@@ -195,6 +215,16 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
           ver="${{ steps.version.outputs.version }}"
+          if [ "${{ steps.version.outputs.cycle }}" = "true" ]; then
+            # opening a cycle only moves the version off the release just made,
+            # so it carries none of the checklist a release needs
+            gh pr create -B main -H "${{ steps.version.outputs.branch }}" \
+              --title "chore: open the $ver development cycle" \
+              --body "Sets the version to \`$ver\` now that the last release is out, so a build from \`main\` is not mistaken for it.
+
+          The citation stays at the released version, which is the one to cite, and moves when the next release is cut."
+            exit 0
+          fi
           body='
           # mf6adj '$ver'
 


### PR DESCRIPTION
The workflow has a `dev` bump that computes the right version for the next development cycle, but the rest of the prep job then treats it as a release. Opening the 1.3.0 and 1.4.0 cycles was done by hand instead (#75, #127), which is a step that has to be remembered after every release.

Four things went wrong with it. The first would have caused real trouble:

| | before | after |
| --- | --- | --- |
| branch name | `v1.4.0.dev0` | `open-1.4.0.dev0-cycle` |
| changelog | an entry with no PRs behind it | skipped |
| `CITATION.cff` | moved to a version nobody cites | skipped |
| pull request | titled as a release, with a release checklist | says what it is |

The branch name matters because the job that drafts a GitHub release triggers on a merged branch whose name starts with `v`. Merging a development cycle would have drafted a release of a dev version.

Every other bump is unchanged. Checked across all six: `major`, `minor`, `patch`, `stable` and `rc` all keep the `v<version>` branch and the release path; only `dev` takes the new one.

If this is merged first, #127 can be closed and the 1.4.0 cycle opened by dispatching `dev`, which exercises the fix on its first real use.