### PR TITLE
ci(changelog): select release entries by commit type, with git-cliff

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -161,8 +161,6 @@ jobs:
         # a cycle is opened with nothing merged behind it, so an entry for it
         # would be empty
         if: ${{ steps.version.outputs.cycle != 'true' }}
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
         run: |
           uv run scripts/generate_changelog.py --version ${{ steps.version.outputs.version }}
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -65,8 +65,8 @@ The **Prepare release** job runs on `main` and:
 1. Resolves the new version from the current one and the bump.
 2. Updates `mf6adj/version.py`, and `CITATION.cff` to the version being
    released.
-3. Generates the `changelog/CHANGELOG.md` entry from the pull requests merged
-   since the last tag.
+3. Generates the `changelog/CHANGELOG.md` entry with git-cliff, from the
+   commits merged since the last tag.
 4. Builds the package, checks it with `twine`, and smoke tests both the wheel
    and the source distribution by importing them and asserting the version.
 5. Pushes a `v<version>` branch and opens a **draft** pull request against
@@ -91,28 +91,27 @@ release just made. Merging its pull request is all it needs.
 To see the entry before starting a release:
 
 ```bash
-pixi run python scripts/generate_changelog.py --version 1.4.0 --dry-run
+pixi run changelog --version 1.4.0 --dry-run
 ```
 
 ---
 
 ## Step 3 — Write the breaking changes, then merge
 
-The generated entry has a `### Changes` section and nothing else. Two things
-are added by hand on the release branch, editing
-`changelog/CHANGELOG.md` directly on GitHub:
+The generated entry has a `### Changes` section and nothing else. A
+`### Breaking changes` section is written by hand above it, editing
+`changelog/CHANGELOG.md` directly on GitHub. It is the part of the release
+notes that is read most and the part no tool can write. A change belongs there
+if it stops something working, or if it changes a number a previous release
+reported: someone holding results from an earlier version needs to know whether
+to run them again, and how far out they were.
 
-- **A `### Breaking changes` section**, above `### Changes`. This is the part
-  of the release notes that is read most and the part no tool can write. A
-  change belongs here if it stops something working, or if it changes a number
-  a previous release reported: someone holding results from an earlier version
-  needs to know whether to run them again, and how far out they were.
-- **Removing the chores.** The generator lists every merged pull request, so
-  the entry arrives carrying dependabot bumps, continuous integration changes
-  and the development-cycle commit. Keep `feat`, `fix`, `refactor` and `build`;
-  drop `ci`, `test`, `style` and `chore`, and the unprefixed dependabot titles.
-  `docs` is usually a chore, but not when it adds a document that is itself a
-  deliverable.
+The chores are already gone, because git-cliff selects on the conventional
+commit type in each pull request title. It keeps `feat`, `fix`, `perf`,
+`refactor`, `build` and `docs`, and drops everything else, including a title
+written with no type at all. `docs` is kept because a document can itself be a
+deliverable, so a documentation change that is housekeeping is the one entry
+that may still want deleting. The lists are in `cliff.toml`.
 
 Then check `mf6adj/version.py`, mark the pull request **Ready for review**, and
 merge it into `main`.
@@ -178,7 +177,7 @@ pull request it opens. See step 2.
 
 - [ ] **Release** run from the Actions tab with the right bump
 - [ ] Prep commit visible on the `v<version>` branch
-- [ ] `### Breaking changes` written, chores removed from the entry
+- [ ] `### Breaking changes` written, and the entry reads right
 - [ ] `mf6adj/version.py` shows the right version
 - [ ] Draft pull request merged into `main`
 - [ ] Draft GitHub release reviewed and published

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,59 @@
+# Configuration for git-cliff, which writes the changelog entry for a release.
+#
+# The entry is built from the commits on main since the last tag. Every pull
+# request is squash merged, so one commit is one pull request and its subject
+# is the pull request title, which is written as the changelog line.
+#
+# What reaches the entry is decided by the conventional commit type in that
+# title. A type that is not listed below is dropped, so a title written without
+# one is dropped as well.
+
+[changelog]
+# Keep a Changelog, and the heading the release workflow looks for when it
+# takes this version's entry out of the file for the release notes.
+body = """
+{% if version %}\
+## [{{ version | trim_start_matches(pat="v") }}] - {{ now() | date(format="%Y-%m-%d") }}
+{% else %}\
+## [unreleased]
+{% endif %}
+### Changes
+{% for commit in commits %}
+- {{ commit.message | split(pat="\n") | first | trim }}\
+{% endfor %}
+"""
+trim = true
+
+[git]
+# The type is matched against the whole subject below rather than parsed, so
+# the message stays as written and the line is the pull request title.
+conventional_commits = false
+filter_unconventional = false
+# a commit no parser gives a group to is dropped
+filter_commits = true
+split_commits = false
+commit_preprocessors = [
+    { pattern = "^ *", replace = "" },
+]
+commit_parsers = [
+    # kept: the work a reader of the release notes came for. `build` is here
+    # because a change to what the package requires is a change a user feels,
+    # and `docs` because a document can itself be a deliverable.
+    { message = "(?i)^feat", group = "changes" },
+    { message = "(?i)^fix", group = "changes" },
+    { message = "(?i)^perf", group = "changes" },
+    { message = "(?i)^refactor", group = "changes" },
+    { message = "(?i)^build", group = "changes" },
+    { message = "(?i)^doc", group = "changes" },
+    # dropped: work on the repository rather than on what it installs
+    { message = "(?i)^ci", skip = true },
+    { message = "(?i)^test", skip = true },
+    { message = "(?i)^styl", skip = true },
+    { message = "(?i)^chore", skip = true },
+    { message = "(?i)^release", skip = true },
+    # and anything else, including a title written without a type
+    { message = ".*", skip = true },
+]
+protect_breaking_commits = false
+tag_pattern = "v[0-9]*"
+sort_commits = "oldest"

--- a/pixi.lock
+++ b/pixi.lock
@@ -419,6 +419,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/58/b4/ad71e051b34f1935783de37beffee16e343ff2514b204dc515f9e939d4af/hatch_fancy_pypi_readme-25.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bb/4a/2e5583e544bc437d5e8e54b47db87430df9031b29b48d17f26d129fa60c0/trove_classifiers-2026.1.14.14-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d3/8a/44032265776062a89171285ede55a0bdaadc8ac00f27f0512a71a9e3e1c8/hatchling-1.29.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f0/4a/98b8d2f53a2d0b7d313e98ab363ad7e0d6a514e878a8d678f22402cb0ec7/git_cliff-2.13.1-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       linux-aarch64:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/_openmp_mutex-4.5-20_gnu.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/alsa-lib-1.2.16.1-h5bc82ec_1.conda
@@ -809,6 +810,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/40/54/b9aaf8e4867e95ac8ea27cd3249946c62c58058779e998040442d6d07625/rtds_action-1.1.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/58/b4/ad71e051b34f1935783de37beffee16e343ff2514b204dc515f9e939d4af/hatch_fancy_pypi_readme-25.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bb/4a/2e5583e544bc437d5e8e54b47db87430df9031b29b48d17f26d129fa60c0/trove_classifiers-2026.1.14.14-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c7/07/cdd149b3909644aa3f0be7960406d9bbb38598f8618e039ac48cbb43ded6/git_cliff-2.13.1-py3-none-manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/d3/8a/44032265776062a89171285ede55a0bdaadc8ac00f27f0512a71a9e3e1c8/hatchling-1.29.0-py3-none-any.whl
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/affine-2.4.0-pyhd8ed1ab_1.conda
@@ -1144,6 +1146,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-1.3.2-h8088a28_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-ng-2.3.3-hed4e4f5_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
+      - pypi: https://files.pythonhosted.org/packages/22/df/842973ead79d27a58cd1eccd167191c0a71513e5c1e9dc30337dafdb7d36/git_cliff-2.13.1-py3-none-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/3d/ea/ac2bf868899d0d2e82ef72d350d97a846110c709bacf2d968431576ca915/setuptools_scm-9.2.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/40/54/b9aaf8e4867e95ac8ea27cd3249946c62c58058779e998040442d6d07625/rtds_action-1.1.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/58/b4/ad71e051b34f1935783de37beffee16e343ff2514b204dc515f9e939d4af/hatch_fancy_pypi_readme-25.1.0-py3-none-any.whl
@@ -1488,6 +1491,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/3d/ea/ac2bf868899d0d2e82ef72d350d97a846110c709bacf2d968431576ca915/setuptools_scm-9.2.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/40/54/b9aaf8e4867e95ac8ea27cd3249946c62c58058779e998040442d6d07625/rtds_action-1.1.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/58/b4/ad71e051b34f1935783de37beffee16e343ff2514b204dc515f9e939d4af/hatch_fancy_pypi_readme-25.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/99/b2/99fac50978b9a90bfec0f1b89354a667ec83f4990301f6c708abce05484e/git_cliff-2.13.1-py3-none-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/bb/4a/2e5583e544bc437d5e8e54b47db87430df9031b29b48d17f26d129fa60c0/trove_classifiers-2026.1.14.14-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d3/8a/44032265776062a89171285ede55a0bdaadc8ac00f27f0512a71a9e3e1c8/hatchling-1.29.0-py3-none-any.whl
   py312:
@@ -1893,6 +1897,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/7c/a4/81502f486f01db95bc8320646a8a12511f5e556cb63d5e224d91816605c4/trove_classifiers-2026.6.1.19-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a0/30/cbf2883ee604dc83ff510516ae05e93b17bfcb4d18279ae12905e13f49da/vcs_versioning-2.3.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a9/84/1798b6d85ecde0e31546004efd25c5de1b1f49250644a60cce460e12593a/hatchling-1.32.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f0/4a/98b8d2f53a2d0b7d313e98ab363ad7e0d6a514e878a8d678f22402cb0ec7/git_cliff-2.13.1-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
 packages:
 - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
   build_number: 20
@@ -18609,6 +18614,11 @@ packages:
   version: 0.15.1
   sha256: 177a05aece5a8ca5266fd3c448abb47b8d352f09d477d3ca8332db4d89b24304
   requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/22/df/842973ead79d27a58cd1eccd167191c0a71513e5c1e9dc30337dafdb7d36/git_cliff-2.13.1-py3-none-macosx_11_0_arm64.whl
+  name: git-cliff
+  version: 2.13.1
+  sha256: e92cf470ecbe73f7d2963dfa80e8961a6b76888d0c19949b0f028a28a0a0470c
+  requires_python: '>=3.7'
 - pypi: https://files.pythonhosted.org/packages/3d/ea/ac2bf868899d0d2e82ef72d350d97a846110c709bacf2d968431576ca915/setuptools_scm-9.2.2-py3-none-any.whl
   name: setuptools-scm
   version: 9.2.2
@@ -18669,6 +18679,11 @@ packages:
   name: trove-classifiers
   version: 2026.6.1.19
   sha256: ab4c4ec93cc4a4e7815fa759906e05e6bb3f2fbd92ea0f897288c6a43efd15b3
+- pypi: https://files.pythonhosted.org/packages/99/b2/99fac50978b9a90bfec0f1b89354a667ec83f4990301f6c708abce05484e/git_cliff-2.13.1-py3-none-win_amd64.whl
+  name: git-cliff
+  version: 2.13.1
+  sha256: 856d831a0bede9c258229dbd4d4c2b1c0810d8fce3d3882729669e8dc09c72bf
+  requires_python: '>=3.7'
 - pypi: https://files.pythonhosted.org/packages/a0/30/cbf2883ee604dc83ff510516ae05e93b17bfcb4d18279ae12905e13f49da/vcs_versioning-2.3.4-py3-none-any.whl
   name: vcs-versioning
   version: 2.3.4
@@ -18694,6 +18709,11 @@ packages:
   name: trove-classifiers
   version: 2026.1.14.14
   sha256: 1f9553927f18d0513d8e5ff80ab8980b8202ce37ecae0e3274ed2ef11880e74d
+- pypi: https://files.pythonhosted.org/packages/c7/07/cdd149b3909644aa3f0be7960406d9bbb38598f8618e039ac48cbb43ded6/git_cliff-2.13.1-py3-none-manylinux_2_28_aarch64.whl
+  name: git-cliff
+  version: 2.13.1
+  sha256: a93db30da45967c42df607fbbc2092111fcd576b0ca9e2fbddd3f653d8c71be7
+  requires_python: '>=3.7'
 - pypi: https://files.pythonhosted.org/packages/d3/8a/44032265776062a89171285ede55a0bdaadc8ac00f27f0512a71a9e3e1c8/hatchling-1.29.0-py3-none-any.whl
   name: hatchling
   version: 1.29.0
@@ -18705,3 +18725,8 @@ packages:
   - tomli>=1.2.2 ; python_full_version < '3.11'
   - trove-classifiers
   requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/f0/4a/98b8d2f53a2d0b7d313e98ab363ad7e0d6a514e878a8d678f22402cb0ec7/git_cliff-2.13.1-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+  name: git-cliff
+  version: 2.13.1
+  sha256: 1ab059d671565189faa4f3858b2fb42535aa39fe265ad95d84d5c116a2724fc7
+  requires_python: '>=3.7'

--- a/pixi.toml
+++ b/pixi.toml
@@ -73,6 +73,9 @@ default = ["py311"]
 py312 = ["py312"]
 
 [pypi-dependencies]
+# conda-forge is several versions behind on git-cliff everywhere but macOS,
+# and PyPI has a wheel for every platform this project is solved for
+git-cliff = ">=2.13,<3"
 hatchling = ">=1.27.0,<2"
 hatch-fancy-pypi-readme = "*"
 rtds-action = "*"
@@ -122,6 +125,11 @@ clean-tests = { cmd = "rm -rf *_test", cwd = "autotest" }
 
 # coverage report
 coverage-report = { cmd = "coverage report", cwd = "autotest"}
+
+# release
+# The version being cut has to be given, and --dry-run prints the entry rather
+# than writing it: pixi run changelog --version 1.4.0 --dry-run
+changelog = { cmd = "python scripts/generate_changelog.py" }
 
 # docs
 docs-install = { cmd = "pip install --no-deps --disable-pip-version-check -e '.[doc]'" }

--- a/scripts/generate_changelog.py
+++ b/scripts/generate_changelog.py
@@ -49,7 +49,7 @@ def build_entry(version):
     if command is None:
         raise SystemExit(
             f"git-cliff was not found, and neither was uvx to run it with.\n"
-            f"Install it with `pixi install`, or `uv tool install {_requirement}`."
+            f'Install it with `pixi install`, or `uv tool install "{_requirement}"`.'
         )
 
     result = subprocess.run(

--- a/scripts/generate_changelog.py
+++ b/scripts/generate_changelog.py
@@ -1,144 +1,98 @@
-"""Generate a changelog entry for a new release.
+"""Generate the changelog entry for a new release.
 
-Uses merged GitHub pull requests since the last tag as the source of changes.
-Falls back to git commit messages if the GitHub CLI is unavailable.
+The entry is built by git-cliff from the commits merged since the last tag,
+which selects on the conventional commit type in each subject. What is kept and
+what is dropped is set in `cliff.toml`.
 
-The generated entry is prepended to changelog/CHANGELOG.md after the header block.
+git-cliff writes a whole changelog rather than an entry, and this file is not
+wholly generated: the breaking changes of a release are written by hand and
+have to survive the next one. So the entry is generated on its own and inserted
+below the header, leaving everything already in the file alone.
 
 Usage:
     python scripts/generate_changelog.py --version 1.2.3
-    python scripts/generate_changelog.py --version 1.2.3 --repo INTERA-Inc/mf6adj
     python scripts/generate_changelog.py --version 1.2.3 --dry-run
 """
 
 import argparse
-import json
+import shutil
 import subprocess
 import sys
 import textwrap
-from datetime import datetime
 from pathlib import Path
 
 _project_root = Path(__file__).parent.parent
 _changelog_path = _project_root / "changelog" / "CHANGELOG.md"
-_default_repo = "INTERA-Inc/mf6adj"
+_config_path = _project_root / "cliff.toml"
+
+# the range git-cliff has been read against; a new major version of it may
+# write the entry differently
+_requirement = "git-cliff>=2.13,<3"
 
 
-def get_previous_tag():
-    """Return the most recent git tag, or None if no tags exist."""
-    result = subprocess.run(
-        ["git", "describe", "--tags", "--abbrev=0"],
-        capture_output=True,
-        text=True,
-    )
-    return result.stdout.strip() if result.returncode == 0 else None
+def git_cliff_command():
+    """Return the command that runs git-cliff, or None if there is none.
 
-
-def get_prs_since_tag(tag, repo):
-    """Return merged PRs since the given tag using the GitHub CLI.
-
-    Returns a list of dicts with keys: number, title, author login.
-    Returns None if the GitHub CLI is unavailable or the call fails.
+    Prefers an installed git-cliff, which is what the pixi environment has, and
+    falls back to running it through uv, which is what the release workflow has.
     """
-    if tag:
-        date_result = subprocess.run(
-            ["git", "log", "-1", "--format=%aI", tag],
-            capture_output=True,
-            text=True,
+    if shutil.which("git-cliff"):
+        return ["git-cliff"]
+    if shutil.which("uvx"):
+        return ["uvx", "--from", _requirement, "git-cliff"]
+    return None
+
+
+def build_entry(version):
+    """Return the entry for a version, built from the commits since the last tag."""
+    command = git_cliff_command()
+    if command is None:
+        raise SystemExit(
+            f"git-cliff was not found, and neither was uvx to run it with.\n"
+            f"Install it with `pixi install`, or `uv tool install {_requirement}`."
         )
-        if date_result.returncode != 0:
-            return None
-        since = date_result.stdout.strip()
-        search = f"merged:>{since}"
-    else:
-        search = "is:merged"
 
     result = subprocess.run(
         [
-            "gh",
-            "pr",
-            "list",
-            "--state",
-            "merged",
-            "--json",
-            "number,title,author,mergedAt",
-            "--search",
-            search,
-            "--repo",
-            repo,
-            "--limit",
-            "200",
+            *command,
+            "--config",
+            str(_config_path),
+            "--unreleased",
+            "--tag",
+            f"v{version}",
         ],
+        cwd=_project_root,
         capture_output=True,
         text=True,
     )
     if result.returncode != 0:
-        return None
+        raise SystemExit(f"git-cliff failed:\n{result.stderr}")
 
-    prs = json.loads(result.stdout)
-    return sorted(prs, key=lambda x: x["mergedAt"])
-
-
-def get_commits_since_tag(tag):
-    """Return non-merge commit subjects since the given tag (or all if no tag)."""
-    base = f"{tag}..HEAD" if tag else "HEAD"
-    result = subprocess.run(
-        ["git", "log", base, "--oneline", "--no-merges"],
-        capture_output=True,
-        text=True,
-    )
-    if result.returncode != 0 or not result.stdout.strip():
-        return []
-    commits = []
-    for line in result.stdout.strip().splitlines():
-        # strip short hash prefix (first word)
-        parts = line.split(" ", 1)
-        commits.append(parts[1] if len(parts) == 2 else line)
-    return commits
+    entry = result.stdout.strip()
+    if not entry:
+        raise SystemExit(
+            "git-cliff produced no entry. Nothing has been merged since the "
+            "last tag whose type reaches the changelog; see cliff.toml."
+        )
+    return entry
 
 
-def build_entry(version, prs=None, commits=None):
-    """Build a Keep-a-Changelog formatted entry string."""
-    today = datetime.now().strftime("%Y-%m-%d")
-    lines = [f"## [{version}] - {today}", ""]
-
-    if prs:
-        lines += ["### Changes", ""]
-        for pr in prs:
-            author = pr.get("author", {}).get("login", "")
-            author_str = f" (@{author})" if author else ""
-            lines.append(f"- {pr['title']} (#{pr['number']}){author_str}")
-        lines.append("")
-    elif commits:
-        lines += ["### Changes", ""]
-        for msg in commits:
-            lines.append(f"- {msg}")
-        lines.append("")
-    else:
-        lines += ["### Changes", "", "- No recorded changes", ""]
-
-    return "\n".join(lines)
-
-
-def prepend_entry(entry, dry_run=False):
-    """Insert the entry into CHANGELOG.md after the header block."""
+def insert_entry(entry, dry_run=False):
+    """Insert the entry below the header, above the entry of the last release."""
     content = _changelog_path.read_text(encoding="utf-8")
     lines = content.splitlines(keepends=True)
 
-    # Find the first blank line after the header (before any ## section)
     insert_pos = len(lines)
     for i, line in enumerate(lines):
         if line.startswith("## "):
             insert_pos = i
             break
 
-    # Ensure a blank line separates header from new entry
-    new_block = entry + "\n\n"
-    updated = "".join(lines[:insert_pos]) + new_block + "".join(lines[insert_pos:])
+    updated = "".join(lines[:insert_pos]) + entry + "\n\n" + "".join(lines[insert_pos:])
 
     if dry_run:
-        print("--- DRY RUN: CHANGELOG.md would be updated as follows ---")
-        print(updated)
+        print(f"--- DRY RUN: {_changelog_path.name} would gain ---")
+        print(entry)
     else:
         _changelog_path.write_text(updated, encoding="utf-8")
         print(f"Updated {_changelog_path}")
@@ -157,34 +111,13 @@ def main():
         help="Version number for the new release (e.g. 1.2.3)",
     )
     parser.add_argument(
-        "--repo",
-        default=_default_repo,
-        help=f"GitHub repository in owner/name format (default: {_default_repo})",
-    )
-    parser.add_argument(
         "--dry-run",
         action="store_true",
-        help="Print the updated changelog without writing to disk",
+        help="Print the entry without writing to disk",
     )
     args = parser.parse_args()
 
-    tag = get_previous_tag()
-    if tag:
-        print(f"Generating changelog since tag: {tag}")
-    else:
-        print("No previous tags found — including all changes")
-
-    prs = get_prs_since_tag(tag, args.repo)
-    if prs is not None:
-        print(f"Found {len(prs)} merged PR(s) via GitHub CLI")
-        entry = build_entry(args.version, prs=prs)
-    else:
-        print("GitHub CLI unavailable or failed — falling back to git log")
-        commits = get_commits_since_tag(tag)
-        print(f"Found {len(commits)} commit(s) via git log")
-        entry = build_entry(args.version, commits=commits)
-
-    prepend_entry(entry, dry_run=args.dry_run)
+    insert_entry(build_entry(args.version), dry_run=args.dry_run)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The changelog entry listed every merged pull request since the last tag, so 14 of the 38 entries in 1.3.0 were chores taken out by hand on the release branch. git-cliff now builds the entry and selects on the conventional commit type, which every pull request title here already carries.

`cliff.toml` keeps `feat`, `fix`, `perf`, `refactor`, `build` and `docs`, and drops everything else. `build` is kept because a change to what the package requires is a change a user feels, and `docs` because a document can itself be a deliverable — dropping it would have lost #89.

The file is not wholly generated, since the breaking changes of a release are written by hand and have to survive the next one, so `generate_changelog.py` now runs git-cliff for the unreleased range and inserts that entry below the header. Its fallback to raw git log is gone.

Run against `v1.2.0..v1.3.0` it reproduces the 24 published entries and one more, `docs(changelog): remove the duplicate 1.1.0 entry (#74)`, which is the housekeeping case `docs` admits.

Closes #126