### PR TITLE
feat(pm): write and read a performance measure from columns

### DIFF
--- a/autotest/test_pm_write.py
+++ b/autotest/test_pm_write.py
@@ -1,0 +1,424 @@
+"""
+Tests for writing and reading a performance measure.
+
+A measure is a set of locations crossed with a set of times, and callers build
+it from a dict, a numpy recarray, or a dataframe. The columns are written as
+ascii, which is what MODFLOW 6 input is, or as hdf5, which is smaller.
+
+Cases:
+  - test_matches_hand_written  : the file matches what the tests write by hand.
+  - test_container             : dict, recarray and dataframe give one file.
+  - test_times_are_crossed     : `times` crosses with the locations, time
+                                 slowest, and `all_times` covers periods that
+                                 hold different numbers of time steps.
+  - test_per_entry_times       : `kper` and `kstp` are one value per entry.
+  - test_value_columns         : a value is a scalar, per location, or per entry.
+  - test_discretization        : dis, disv and disu round trip.
+  - test_round_trip            : ascii -> hdf5 -> ascii is unchanged.
+  - test_hdf5_is_smaller       : the hdf5 file is the smaller of the two,
+                                 which a column of names held as variable-
+                                 length strings would not be.
+  - test_reads_hand_written    : comments, blank lines and mixed case read.
+  - test_committed_files       : the measures kept in the repository read.
+  - test_refusals              : the input a measure cannot be built from.
+  - test_solves_the_same       : a model solved from a written file and from a
+                                 hand-written one gives the same sensitivities.
+  - test_solves_from_hdf5      : the same measure written as hdf5 is read and
+                                 solved, and gives the same sensitivities.
+"""
+
+import pathlib as pl
+import shutil
+import sys
+
+import flopy
+import numpy as np
+import pandas as pd
+import pytest
+
+try:
+    import mf6adj
+except ImportError:
+    sys.path.insert(0, str(pl.Path("../").resolve()))
+    import mf6adj
+
+from mf6adj import all_times, read_performance_measures, write_performance_measures
+
+mf6_bin, lib_name = mf6adj.get_conda_mf6_paths()
+
+CELLS = [(0, 1, 2), (0, 1, 3), (1, 4, 5)]
+
+
+def entries(path):
+    """Return the entry lines of a written file."""
+    return [
+        ln.strip()
+        for ln in pl.Path(path).read_text().splitlines()
+        if ln.strip() and not ln.strip().lower().startswith(("begin", "end"))
+    ]
+
+
+def test_matches_hand_written(function_tmpdir):
+    """The written file is what the tests write by hand, one-based."""
+    path = write_performance_measures(
+        function_tmpdir / "t.adj", {"pm": {"cellid": CELLS, "pm_type": "lak-1"}}
+    )
+    hand = [f"1 1 {k + 1} {i + 1} {j + 1} lak-1 direct 1.0 -1e+30" for k, i, j in CELLS]
+    assert entries(path) == hand
+
+
+def test_container(function_tmpdir):
+    """A dict, a recarray, and a dataframe give the same file."""
+    layer, row, column = (np.array(c) for c in zip(*CELLS))
+    columns = {
+        "layer": layer,
+        "row": row,
+        "column": column,
+        "pm_type": np.array(["ghb-1"] * 3),
+        "weight": np.array([1.0, 2.0, 3.0]),
+    }
+    rec = np.rec.fromarrays(list(columns.values()), names=list(columns))
+    frame = pd.DataFrame(columns)
+
+    written = [
+        write_performance_measures(
+            function_tmpdir / f"{tag}.adj", {"pm": measure}
+        ).read_text()
+        for tag, measure in (("d", columns), ("r", rec), ("f", frame))
+    ]
+    assert written[0] == written[1] == written[2]
+
+
+def test_times_are_crossed(function_tmpdir):
+    """`times` crosses with the locations, the time varying slowest."""
+    path = write_performance_measures(
+        function_tmpdir / "t.adj",
+        {"pm": {"cellid": CELLS, "times": range(3), "pm_type": "head"}},
+    )
+    lines = entries(path)
+    assert len(lines) == 9
+    assert [ln.split()[0] for ln in lines] == ["1"] * 3 + ["2"] * 3 + ["3"] * 3
+    assert [ln.split()[4] for ln in lines] == ["3", "4", "6"] * 3
+
+    # a period holding three time steps, which no cross of two axes gives
+    path = write_performance_measures(
+        function_tmpdir / "s.adj",
+        {"pm": {"cellid": CELLS[:1], "times": all_times([1, 3]), "pm_type": "head"}},
+    )
+    assert [ln.split()[:2] for ln in entries(path)] == [
+        ["1", "1"],
+        ["2", "1"],
+        ["2", "2"],
+        ["2", "3"],
+    ]
+
+
+def test_per_entry_times(function_tmpdir):
+    """`kper` and `kstp` are one value per entry rather than an axis."""
+    path = write_performance_measures(
+        function_tmpdir / "t.adj",
+        {
+            "pm": {
+                "cellid": CELLS,
+                "kper": [0, 1, 2],
+                "kstp": [0, 0, 1],
+                "pm_type": "head",
+            }
+        },
+    )
+    lines = entries(path)
+    assert len(lines) == 3
+    assert [ln.split()[:2] for ln in lines] == [["1", "1"], ["2", "1"], ["3", "2"]]
+
+
+def test_value_columns(function_tmpdir):
+    """A value is a scalar, one per location, or one per entry."""
+    measure = {
+        "cellid": CELLS,
+        "times": range(2),
+        "pm_type": "head",
+        "weight": [1.0, 2.0, 3.0],  # per location, repeated each time
+        "obsval": np.arange(6, dtype=float),  # per entry
+    }
+    path = write_performance_measures(function_tmpdir / "t.adj", {"pm": measure})
+    lines = entries(path)
+    assert [ln.split()[-2] for ln in lines] == ["1.0", "2.0", "3.0"] * 2
+    assert [ln.split()[-1] for ln in lines] == [f"{v}.0" for v in range(6)]
+
+
+@pytest.mark.parametrize(
+    "cellid, ntoken",
+    [([(0, 1, 2), (1, 3, 4)], 9), ([(0, 5), (1, 6)], 8), ([(7,), (8,)], 7)],
+)
+def test_discretization(function_tmpdir, cellid, ntoken):
+    """A cellid of three, two, or one index is dis, disv, or disu."""
+    path = write_performance_measures(
+        function_tmpdir / "t.adj", {"pm": {"cellid": cellid, "pm_type": "head"}}
+    )
+    assert all(len(ln.split()) == ntoken for ln in entries(path))
+
+    measures, _ = read_performance_measures(path)
+    back = write_performance_measures(function_tmpdir / "b.adj", measures)
+    assert back.read_text() == path.read_text()
+
+
+def test_round_trip(function_tmpdir):
+    """A measure written as ascii, read, and written as hdf5 comes back whole."""
+    options = {"hdf5_name": "out.h5"}
+    measure = {
+        "cellid": CELLS,
+        "times": range(2),
+        "pm_type": "head",
+        "pm_form": "residual",
+        "weight": [1.0, 2.0, 3.0],
+        "obsval": np.arange(6, dtype=float),
+    }
+    ascii_path = write_performance_measures(
+        function_tmpdir / "t.adj", {"pm": measure}, options=options
+    )
+
+    first, first_options = read_performance_measures(ascii_path)
+    h5 = write_performance_measures(
+        function_tmpdir / "t.h5", first, options=first_options, format="hdf5"
+    )
+    assert mf6adj.utils.utils_pm_write.is_hdf5(h5)
+
+    second, second_options = read_performance_measures(h5)
+    again = write_performance_measures(
+        function_tmpdir / "again.adj", second, options=second_options
+    )
+    assert again.read_text() == ascii_path.read_text()
+    assert dict(second_options) == options
+    for name in first:
+        for column in first[name]:
+            assert np.array_equal(first[name][column], second[name][column]), column
+
+
+HAND_WRITTEN = """\
+# a measure written by hand, as the tests write them
+
+begin options
+  hdf5_name out.h5
+end options
+
+BEGIN PERFORMANCE_MEASURE Head
+  1 1 3 5 2 head direct 1.0 -1.0e+30
+  2 1 3 5 2 head residual 2.5 34.125
+
+end performance_measure
+
+begin performance_measure sfr
+  # a comment inside a block
+  2 1 2 4 1 sfr_1 direct 1.0 -1.0e+30
+end performance_measure
+"""
+
+
+def test_hdf5_is_smaller(function_tmpdir):
+    """hdf5 is the smaller format, which is the reason to offer it.
+
+    A column of package names held as variable-length strings carries a pointer
+    and a heap entry for every entry and does not compress, which made the hdf5
+    file larger than the ascii one it replaces.
+    """
+    nentry = 20_000
+    rng = np.random.default_rng(0)
+    measure = {
+        "layer": rng.integers(0, 4, nentry),
+        "row": rng.integers(0, 800, nentry),
+        "column": rng.integers(0, 1000, nentry),
+        "pm_type": np.where(rng.random(nentry) < 0.5, "drn-1", "ghb-1"),
+    }
+    ascii_path = write_performance_measures(function_tmpdir / "m.adj", {"m": measure})
+    h5_path = write_performance_measures(
+        function_tmpdir / "m.h5", {"m": measure}, format="hdf5"
+    )
+
+    ascii_size = ascii_path.stat().st_size
+    h5_size = h5_path.stat().st_size
+    assert h5_size < ascii_size / 3, f"hdf5 {h5_size} against ascii {ascii_size}"
+
+
+def test_reads_hand_written(function_tmpdir):
+    """A file with comments, blank lines, and mixed case reads as written."""
+    path = function_tmpdir / "hand.adj"
+    path.write_text(HAND_WRITTEN)
+
+    measures, options = read_performance_measures(path)
+    assert options == {"hdf5_name": "out.h5"}
+    assert sorted(measures) == ["head", "sfr"]
+
+    head = measures["head"]
+    assert np.array_equal(head["kper"], [0, 1])
+    assert np.array_equal(head["layer"], [2, 2])
+    assert np.array_equal(head["row"], [4, 4])
+    assert np.array_equal(head["column"], [1, 1])
+    assert list(head["pm_form"]) == ["direct", "residual"]
+    assert np.array_equal(head["weight"], [1.0, 2.5])
+    assert np.array_equal(head["obsval"], [-1.0e30, 34.125])
+    assert list(measures["sfr"]["pm_type"]) == ["sfr_1"]
+
+    # and it writes back to the same entries it was read from
+    again = write_performance_measures(
+        function_tmpdir / "again.adj", measures, options=options
+    )
+    back, back_options = read_performance_measures(again)
+    assert back_options == options
+    for name in measures:
+        for column in measures[name]:
+            assert np.array_equal(measures[name][column], back[name][column]), column
+
+
+def test_committed_files(function_tmpdir):
+    """The measures kept in the repository read and write back unchanged."""
+    root = pl.Path(__file__).parent.parent
+    paths = [
+        root / "autotest/ie_1sp/ie_perfmeas.dat",
+        root / "examples/xd_box_chd_ana/test.adj",
+    ]
+
+    for path in paths:
+        if not path.is_file():
+            continue
+        measures, options = read_performance_measures(path)
+        assert measures, path
+        again = write_performance_measures(
+            function_tmpdir / "rt.adj", measures, options=options
+        )
+        back, _ = read_performance_measures(again)
+        assert measures.keys() == back.keys(), path
+        for name in measures:
+            for column in measures[name]:
+                assert np.array_equal(measures[name][column], back[name][column]), (
+                    f"{path} {name} {column}"
+                )
+
+
+def test_refusals(function_tmpdir):
+    """Input a measure cannot be built from is refused where it is given."""
+    path = function_tmpdir / "t.adj"
+
+    with pytest.raises(Exception, match="pm_type"):
+        write_performance_measures(path, {"pm": {"cellid": CELLS}})
+
+    with pytest.raises(Exception, match="locations"):
+        write_performance_measures(path, {"pm": {"row": [1], "pm_type": "head"}})
+
+    with pytest.raises(Exception, match="not as both"):
+        write_performance_measures(
+            path,
+            {"pm": {"cellid": CELLS, "times": range(2), "kper": 1, "pm_type": "head"}},
+        )
+
+    with pytest.raises(Exception, match="do not broadcast"):
+        write_performance_measures(
+            path,
+            {"pm": {"cellid": CELLS, "times": (range(3), range(2)), "pm_type": "head"}},
+        )
+
+    with pytest.raises(Exception, match="weight"):
+        write_performance_measures(
+            path, {"pm": {"cellid": CELLS, "pm_type": "head", "weight": [1.0, 2.0]}}
+        )
+
+    with pytest.raises(Exception, match="unrecognized"):
+        write_performance_measures(
+            path, {"pm": {"cellid": CELLS, "pm_type": "head", "nonsense": 1}}
+        )
+
+    with pytest.raises(Exception, match="ascii"):
+        write_performance_measures(
+            path, {"pm": {"cellid": CELLS, "pm_type": "head"}}, format="parquet"
+        )
+
+    with pytest.raises(Exception, match="no performance measures"):
+        write_performance_measures(path, {})
+
+
+def _build(ws):
+    """A small confined model with a general-head boundary along one edge."""
+    ws = pl.Path(ws)
+    if ws.exists():
+        shutil.rmtree(ws)
+    ws.mkdir(parents=True)
+    sim = flopy.mf6.MFSimulation(sim_name="pmw", sim_ws=str(ws), exe_name=mf6_bin)
+    flopy.mf6.ModflowTdis(sim, nper=2, perioddata=[(1.0, 1, 1.0)] * 2)
+    flopy.mf6.ModflowIms(sim, complexity="simple")
+    gwf = flopy.mf6.ModflowGwf(sim, modelname="pmw", save_flows=True)
+    flopy.mf6.ModflowGwfdis(
+        gwf, nlay=2, nrow=5, ncol=5, delr=10.0, delc=10.0, top=10.0, botm=[5.0, 0.0]
+    )
+    flopy.mf6.ModflowGwfic(gwf, strt=8.0)
+    flopy.mf6.ModflowGwfnpf(gwf, icelltype=0, k=10.0, k33=1.0)
+    flopy.mf6.ModflowGwfsto(gwf, iconvert=0, ss=1.0e-5, steady_state={0: True})
+    flopy.mf6.ModflowGwfghb(
+        gwf,
+        stress_period_data=[[(0, i, 0), 9.0, 100.0] for i in range(5)],
+        pname="ghb-1",
+    )
+    flopy.mf6.ModflowGwfchd(
+        gwf, stress_period_data=[[(0, i, 4), 6.0] for i in range(5)], pname="chd-1"
+    )
+    flopy.mf6.ModflowGwfoc(gwf, head_filerecord="pmw.hds", saverecord=[("HEAD", "ALL")])
+    sim.write_simulation(silent=True)
+    success, buff = sim.run_simulation(silent=True)
+    assert success, "\n".join(buff[-20:])
+    return ws
+
+
+def _solve(ws):
+    """Return the sensitivities of the measure in a workspace."""
+    adj = mf6adj.Mf6Adj(
+        "pm.dat", lib_name, logging_level="ERROR", working_directory=str(ws)
+    )
+    adj.solve_forward_model(hdf5_name="fwd.hd5")
+    df = adj.solve_adjoint()
+    adj.finalize()
+    return df
+
+
+def test_solves_the_same(function_tmpdir):
+    """A written measure gives the sensitivities a hand-written one gives."""
+    cells = [(0, i, 0) for i in range(5)]
+
+    hand_ws = _build(function_tmpdir / "hand")
+    with open(hand_ws / "pm.dat", "w") as f:
+        f.write("begin performance_measure ghb\n")
+        for kper in range(2):
+            for k, i, j in cells:
+                f.write(
+                    f"{kper + 1} 1 {k + 1} {i + 1} {j + 1} ghb-1 direct 1.0 -1.0e+30\n"
+                )
+        f.write("end performance_measure\n\n")
+
+    written_ws = _build(function_tmpdir / "written")
+    write_performance_measures(
+        written_ws / "pm.dat",
+        {"ghb": {"cellid": cells, "times": range(2), "pm_type": "ghb-1"}},
+    )
+
+    hand = _solve(hand_ws)
+    written = _solve(written_ws)
+
+    assert hand.keys() == written.keys()
+    for name in hand:
+        pd.testing.assert_frame_equal(hand[name], written[name])
+
+
+def test_solves_from_hdf5(function_tmpdir):
+    """A measure written as hdf5 is read and solved like the ascii one."""
+    cells = [(0, i, 0) for i in range(5)]
+    measures = {"ghb": {"cellid": cells, "times": range(2), "pm_type": "ghb-1"}}
+
+    ascii_ws = _build(function_tmpdir / "ascii")
+    write_performance_measures(ascii_ws / "pm.dat", measures)
+
+    hdf5_ws = _build(function_tmpdir / "hdf5")
+    write_performance_measures(hdf5_ws / "pm.dat", measures, format="hdf5")
+
+    from_ascii = _solve(ascii_ws)
+    from_hdf5 = _solve(hdf5_ws)
+
+    assert from_ascii.keys() == from_hdf5.keys()
+    for name in from_ascii:
+        pd.testing.assert_frame_equal(from_ascii[name], from_hdf5[name])

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -117,6 +117,63 @@ the same file; the adjoint is solved independently for each.
            f.write(f"{kper + 1} 1 2 4 1 sfr_1 direct 1.0 -1.0e+30\n")
        f.write("end performance_measure\n")
 
+Writing a performance measure
+------------------------------
+
+The blocks above can be written with
+:func:`~mf6adj.write_performance_measures` rather than by hand.  It takes the
+measures as a dict of columns, a numpy recarray, or a
+:class:`pandas.DataFrame`, so cell identifiers can come straight from flopy:
+
+.. code-block:: python
+
+   from mf6adj import write_performance_measures
+
+   ghb = gwf.get_package("ghb-1").stress_period_data.get_data()[0]
+
+   write_performance_measures(
+       "model.adj",
+       {
+           "swgw": {
+               "cellid": ghb["cellid"],       # zero-based, as flopy gives it
+               "times": range(nper),          # crossed with the cells
+               "pm_type": "ghb-1",
+               "pm_form": "direct",
+               "weight": 1.0,
+               "obsval": -1.0e30,
+           },
+       },
+       options={"hdf5_name": "out.h5"},
+   )
+
+Indices are zero-based, as they are in flopy; the file itself is one-based and
+the conversion is made on the way out.  ``times`` is crossed with the cells,
+the time varying slowest.  A period holding several time steps is given as a
+``(kper, kstp)`` pair, which :func:`~mf6adj.all_times` builds from the time
+steps per period::
+
+   "times": all_times(sim.tdis.nstp.array)
+
+``kper`` and ``kstp`` may be given instead of ``times``, in which case they are
+one value per entry.  ``weight`` and ``obsval`` are a single value, one value
+per cell, or one value per entry.
+
+A measure with one entry per active cell of a large model makes a sizeable
+file, and ``format="hdf5"`` writes the same measure as compressed columns,
+roughly nine times smaller.  Ascii is the default, since it is the format
+MODFLOW 6 input is written in and is readable in a text editor.
+
+:func:`~mf6adj.read_performance_measures` reads either format, returning the
+measures and the options block in the form the writer accepts, so a file can
+be converted or edited and written back:
+
+.. code-block:: python
+
+   from mf6adj import read_performance_measures, write_performance_measures
+
+   measures, options = read_performance_measures("model.adj")
+   write_performance_measures("model.h5", measures, options=options, format="hdf5")
+
 Solving the forward model and adjoint
 --------------------------------------
 

--- a/mf6adj/__init__.py
+++ b/mf6adj/__init__.py
@@ -4,11 +4,19 @@ from .version import __version__  # isort:skip
 from .adj import Mf6Adj
 from .pm import PerfMeas, PerfMeasRecord
 from .utils.utils import get_conda_mf6_paths
+from .utils.utils_pm_write import (
+    all_times,
+    read_performance_measures,
+    write_performance_measures,
+)
 
 __all__ = [
     "Mf6Adj",
     "PerfMeas",
     "PerfMeasRecord",
     "__version__",
+    "all_times",
     "get_conda_mf6_paths",
+    "read_performance_measures",
+    "write_performance_measures",
 ]

--- a/mf6adj/utils/utils_pm_read.py
+++ b/mf6adj/utils/utils_pm_read.py
@@ -4,6 +4,11 @@ from typing import Callable, Optional
 import numpy as np
 
 from .utils_modflow import SUPPORTED_PACKAGE_TYPES, get_node
+from .utils_pm_write import (
+    LOCATION_COLUMNS,
+    is_hdf5,
+    read_performance_measures,
+)
 
 PathLike = str | pl.Path
 
@@ -138,6 +143,23 @@ def read_adj_file(
         package) also cannot be mixed within a single performance measure.
     """
     hdf5_name = None if current_hdf5_name is None else pl.Path(current_hdf5_name)
+
+    if is_hdf5(adj_filename):
+        return read_adj_hdf5(
+            adj_filename,
+            nuser,
+            nstp,
+            nper,
+            ncpl,
+            is_structured=is_structured,
+            unstructured_type=unstructured_type,
+            shape=shape,
+            gwf_package_dict=gwf_package_dict,
+            record_factory=record_factory,
+            add_performance_measure=add_performance_measure,
+            current_hdf5_name=hdf5_name,
+            logger=logger,
+        )
 
     with pl.Path(adj_filename).open("r") as f:
         count = 0
@@ -372,6 +394,45 @@ def map_reduced_node(
                 logger.info(f"{kij}")
         raise Exception(f"node num {inode} not in reduced node num")
     return int(nn[0])
+
+
+def map_reduced_nodes(
+    inodes: np.ndarray,
+    nuser: np.ndarray,
+    logger=None,
+) -> np.ndarray:
+    """Map full-grid node numbers to the reduced MODFLOW 6 node indices.
+
+    Parameters
+    ----------
+    inodes : ndarray
+        Zero-based full-grid node numbers.
+    nuser : ndarray
+        Zero-based ``NODEUSER`` array from MODFLOW 6.
+    logger : logging.Logger, optional
+        Optional logger used to emit debug context before raising.
+
+    Returns
+    -------
+    ndarray
+        Zero-based reduced node indices.
+    """
+    inodes = np.asarray(inodes, dtype=np.int64)
+    if len(nuser) <= 1:
+        return inodes
+
+    # the inverse of nuser, built once, so a lookup does not scan the model
+    inverse = np.full(int(nuser.max()) + 1, -1, dtype=np.int64)
+    inverse[nuser] = np.arange(nuser.size, dtype=np.int64)
+
+    outside = inodes > inverse.size - 1
+    reduced = np.where(outside, -1, inverse[np.where(outside, 0, inodes)])
+    missing = reduced < 0
+    if missing.any():
+        if logger is not None:
+            logger.info(f"{inodes[missing]}")
+        raise Exception(f"node num {int(inodes[missing][0])} not in reduced node num")
+    return reduced
 
 
 def parse_pm_location(
@@ -653,3 +714,145 @@ def parse_performance_measure_block(
         )
 
     return count, pm_name, pm_entries
+
+
+def read_adj_hdf5(
+    adj_filename: PathLike,
+    nuser: np.ndarray,
+    nstp: np.ndarray,
+    nper: int,
+    ncpl: Optional[int],
+    is_structured: bool,
+    unstructured_type: Optional[str],
+    shape: Optional[tuple[int, ...]],
+    gwf_package_dict: dict[str, list[str]],
+    record_factory: Callable[..., object],
+    add_performance_measure: Callable[[str, list], None],
+    current_hdf5_name: Optional[PathLike] = None,
+    logger=None,
+) -> Optional[pl.Path]:
+    """Read an adjoint input file written as hdf5.
+
+    The entries are held as columns, so the locations and times are checked and
+    mapped for the whole measure at once rather than one line at a time.
+
+    Parameters
+    ----------
+    adj_filename : PathLike
+        Adjoint input filename.
+    nuser : ndarray
+        Reduced-node user mapping.
+    nstp : ndarray
+        Number of time steps per stress period.
+    nper : int
+        Number of stress periods.
+    ncpl : int, optional
+        Cells per layer for `disv`.
+    is_structured : bool
+        Whether the model discretization is structured.
+    unstructured_type : str, optional
+        Unstructured discretization type (`disv` or `disu`).
+    shape : tuple[int, ...], optional
+        Structured-grid shape used to convert layer-row-column locations.
+    gwf_package_dict : dict[str, list[str]]
+        Mapping of package types to package names.
+    record_factory : callable
+        Constructor used to create PM record objects.
+    add_performance_measure : callable
+        Callback used to store each parsed performance measure.
+    current_hdf5_name : PathLike, optional
+        Existing hdf5 name to preserve unless overridden by options.
+    logger : logging.Logger, optional
+        Optional logger for progress and debug context.
+
+    Returns
+    -------
+    pathlib.Path or None
+        Output hdf5 filename from the options, if one is set.
+    """
+    measures, options = read_performance_measures(adj_filename)
+    if not measures:
+        raise Exception("no PMs found in adj file")
+
+    hdf5_name = None if current_hdf5_name is None else pl.Path(current_hdf5_name)
+    for key, value in options.items():
+        if key != "hdf5_name":
+            raise Exception(f"unrecognized option: {key}")
+        hdf5_name = pl.Path(str(value))
+
+    grid = "dis" if is_structured else unstructured_type
+    for name, columns in measures.items():
+        expected = LOCATION_COLUMNS[grid]
+        if any(column not in columns for column in expected):
+            raise Exception(
+                f"performance measure '{name}' does not hold the locations a "
+                f"{grid} model needs, which are {', '.join(expected)}"
+            )
+
+        kper = np.asarray(columns["kper"], dtype=np.int64)
+        kstp = np.asarray(columns["kstp"], dtype=np.int64)
+        if (kper > nper - 1).any():
+            raise Exception(f"kper > nper -1 in performance measure '{name}'")
+        if (kstp > nstp[kper] - 1).any():
+            raise Exception(f"kstp > nstp[kper] -1 in performance measure '{name}'")
+
+        if is_structured:
+            if shape is None:
+                raise Exception("shape is None for structured PM location parsing")
+            inode = np.ravel_multi_index(
+                tuple(np.asarray(columns[c], dtype=np.int64) for c in expected), shape
+            )
+        elif unstructured_type == "disv":
+            if ncpl is None:
+                raise Exception("ncpl is None for disv parsing")
+            inode = ncpl * np.asarray(columns["layer"], dtype=np.int64) + np.asarray(
+                columns["cell2d"], dtype=np.int64
+            )
+        else:
+            inode = np.asarray(columns["node"], dtype=np.int64)
+        inode = map_reduced_nodes(inode, nuser, logger=logger)
+
+        for pm_type in np.unique(columns["pm_type"]):
+            validate_pm_type(
+                str(pm_type), gwf_package_dict=gwf_package_dict, logger=logger
+            )
+
+        if is_structured:
+            kij = list(zip(*(columns[c].tolist() for c in expected)))
+        else:
+            kij = [(None, None, None)] * kper.size
+
+        entries = [
+            record_factory(
+                entry_kper,
+                entry_kstp,
+                entry_node,
+                entry_type,
+                entry_form,
+                entry_weight,
+                entry_obsval,
+                *entry_kij,
+            )
+            for (
+                entry_kper,
+                entry_kstp,
+                entry_node,
+                entry_type,
+                entry_form,
+                entry_weight,
+                entry_obsval,
+                entry_kij,
+            ) in zip(
+                kper.tolist(),
+                kstp.tolist(),
+                inode.tolist(),
+                columns["pm_type"].tolist(),
+                columns["pm_form"].tolist(),
+                columns["weight"].tolist(),
+                columns["obsval"].tolist(),
+                kij,
+            )
+        ]
+        add_performance_measure(name, entries)
+
+    return hdf5_name

--- a/mf6adj/utils/utils_pm_write.py
+++ b/mf6adj/utils/utils_pm_write.py
@@ -1,0 +1,462 @@
+"""Write and read the performance measures of an adjoint input file.
+
+A measure is a set of locations crossed with a set of times, which is the shape
+every caller builds by hand. Columns are given as a dict, a numpy recarray, or a
+dataframe, and are held as one-dimensional arrays, which is the fastest form for
+both the ascii and the hdf5 target.
+
+Indices are zero-based here, as they are elsewhere in mf6adj and in flopy. The
+file is one-based, and the conversion happens on the way out and back.
+"""
+
+import pathlib as pl
+from typing import Any, Iterable, Optional
+
+import numpy as np
+
+PathLike = str | pl.Path
+
+# the location columns of each discretization, in the order the file writes them
+LOCATION_COLUMNS = {
+    "dis": ("layer", "row", "column"),
+    "disv": ("layer", "cell2d"),
+    "disu": ("node",),
+}
+
+# everything a measure carries that is not a location or a time
+VALUE_COLUMNS = ("pm_type", "pm_form", "weight", "obsval")
+
+TIME_COLUMNS = ("kper", "kstp")
+
+_DEFAULTS = {"pm_form": "direct", "weight": 1.0, "obsval": -1.0e30}
+
+
+def all_times(nstp: Iterable[int]) -> tuple[np.ndarray, np.ndarray]:
+    """Return every ``(kper, kstp)`` pair for a model's time steps per period.
+
+    Periods do not have to hold the same number of time steps, so the pairs
+    cannot be formed by crossing one with the other.
+
+    Parameters
+    ----------
+    nstp : iterable of int
+        Number of time steps in each stress period.
+
+    Returns
+    -------
+    tuple[ndarray, ndarray]
+        Zero-based stress periods and time steps, of equal length.
+    """
+    nstp = np.asarray(list(nstp), dtype=np.int64)
+    kper = np.repeat(np.arange(nstp.size, dtype=np.int64), nstp)
+    kstp = np.concatenate(
+        [np.arange(n, dtype=np.int64) for n in nstp]
+        if nstp.size
+        else [np.zeros(0, dtype=np.int64)]
+    )
+    return kper, kstp
+
+
+def as_columns(measure: Any) -> dict[str, Any]:
+    """Return a measure given as a dict, recarray, or dataframe as a dict.
+
+    Parameters
+    ----------
+    measure : dict, ndarray, or DataFrame
+        Measure columns in any of the accepted containers.
+
+    Returns
+    -------
+    dict
+        Column name to value. A recarray field is a view, not a copy.
+    """
+    dtype = getattr(measure, "dtype", None)
+    if dtype is not None and dtype.names:
+        return {name: measure[name] for name in dtype.names}
+    columns = getattr(measure, "columns", None)
+    if columns is not None:
+        return {str(name): measure[name].to_numpy() for name in columns}
+    return dict(measure)
+
+
+def split_cellid(cellid) -> tuple[str, dict[str, np.ndarray]]:
+    """Return the discretization and location columns of a flopy cellid.
+
+    Parameters
+    ----------
+    cellid : sequence
+        Zero-based cell identifiers, each a tuple whose length gives the
+        discretization: three for `dis`, two for `disv`, and one for `disu`.
+
+    Returns
+    -------
+    tuple[str, dict[str, ndarray]]
+        Discretization name and its location columns.
+    """
+    values = np.asarray(cellid)
+    if values.dtype == object or values.ndim == 1:
+        values = np.array([tuple(np.atleast_1d(c)) for c in values], dtype=np.int64)
+    values = np.atleast_2d(values)
+
+    ndim = values.shape[1]
+    grid = {3: "dis", 2: "disv", 1: "disu"}.get(ndim)
+    if grid is None:
+        raise Exception(
+            f"a cellid holds one, two, or three indices, not {ndim}. A cellid "
+            "of three is dis, two is disv, and one is disu."
+        )
+    return grid, {
+        name: values[:, idx].astype(np.int64)
+        for idx, name in enumerate(LOCATION_COLUMNS[grid])
+    }
+
+
+def _locations(columns: dict[str, Any]) -> tuple[str, dict[str, np.ndarray]]:
+    """Return the discretization and location columns of one measure."""
+    if "cellid" in columns:
+        return split_cellid(columns.pop("cellid"))
+
+    for grid, names in LOCATION_COLUMNS.items():
+        if all(name in columns for name in names):
+            return grid, {
+                name: np.asarray(columns.pop(name), dtype=np.int64).ravel()
+                for name in names
+            }
+
+    raise Exception(
+        "a measure gives its locations as `cellid`, or as "
+        + ", or as ".join(
+            "`" + "`, `".join(names) + "`" for names in LOCATION_COLUMNS.values()
+        )
+        + f". Found {sorted(columns)}."
+    )
+
+
+def _times(columns, nloc):
+    """Return the ``(kper, kstp)`` of every entry, and how many entries there are.
+
+    ``times`` is an axis and is crossed with the locations. ``kper`` and
+    ``kstp`` are not: they are a scalar, or one value per entry.
+    """
+    if "times" in columns:
+        if "kper" in columns or "kstp" in columns:
+            raise Exception(
+                "a measure gives its times as `times`, which is crossed with "
+                "the locations, or as `kper` and `kstp`, which are one value "
+                "per entry, but not as both"
+            )
+        times = columns.pop("times")
+        if isinstance(times, tuple) and len(times) == 2:
+            kper, kstp = times
+        else:
+            values = np.asarray(times, dtype=np.int64)
+            if values.ndim == 2 and values.shape[1] == 2:
+                kper, kstp = values[:, 0], values[:, 1]
+            else:
+                kper, kstp = values.ravel(), 0
+        kper = np.atleast_1d(np.asarray(kper, dtype=np.int64)).ravel()
+        kstp = np.atleast_1d(np.asarray(kstp, dtype=np.int64)).ravel()
+        try:
+            kper, kstp = np.broadcast_arrays(kper, kstp)
+        except ValueError:
+            raise Exception(
+                f"`times` holds {kper.size} periods and {kstp.size} time steps, "
+                "which do not broadcast. `all_times` builds the pairs for a "
+                "model whose periods hold different numbers of time steps."
+            ) from None
+        ntime = kper.size
+        at_time = np.repeat(np.arange(ntime), nloc)
+        at_loc = np.tile(np.arange(nloc), ntime)
+        return kper[at_time], kstp[at_time], ntime * nloc, at_loc
+
+    # one value per entry, so the locations already carry every entry
+    kper = _expand("kper", columns.pop("kper", 0), nloc, nloc, np.arange(nloc))
+    kstp = _expand("kstp", columns.pop("kstp", 0), nloc, nloc, np.arange(nloc))
+    return kper, kstp, nloc, np.arange(nloc)
+
+
+def normalize(measure: Any) -> tuple[str, dict[str, np.ndarray]]:
+    """Return one measure as equal-length columns, one row per entry.
+
+    Times are given one of two ways. ``times`` is an axis, crossed with the
+    locations, the time varying slowest; it is a sequence of periods, or a
+    ``(kper, kstp)`` pair, which `all_times` builds for a model whose periods
+    hold different numbers of time steps. ``kper`` and ``kstp`` are instead one
+    value per entry, or a scalar, and are what `read_performance_measures`
+    returns, so a measure read from a file writes back unchanged.
+
+    A value column is a scalar, one value per location, or one value per entry.
+
+    Parameters
+    ----------
+    measure : dict, ndarray, or DataFrame
+        Location, time, and value columns of a measure.
+
+    Returns
+    -------
+    tuple[str, dict[str, ndarray]]
+        Discretization name and its columns, each of length ``nentry``.
+    """
+    columns = as_columns(measure)
+    grid, location = _locations(columns)
+
+    nloc = len(next(iter(location.values())))
+    for name, values in location.items():
+        if len(values) != nloc:
+            raise Exception(
+                f"location column `{name}` has {len(values)} values, and "
+                f"the measure has {nloc} locations"
+            )
+
+    if "pm_type" not in columns:
+        raise Exception("a measure needs a `pm_type`, either `head` or a package name")
+
+    kper, kstp, nentry, at_loc = _times(columns, nloc)
+
+    out = {name: values[at_loc] for name, values in location.items()}
+    out["kper"] = kper
+    out["kstp"] = kstp
+
+    for name in VALUE_COLUMNS:
+        value = columns.pop(name, _DEFAULTS.get(name))
+        out[name] = _expand(name, value, nloc, nentry, at_loc)
+
+    if columns:
+        raise Exception(f"unrecognized columns in a measure: {sorted(columns)}")
+
+    return grid, out
+
+
+def _expand(name, value, nloc, nentry, at_loc) -> np.ndarray:
+    """Return one value column as one value per entry."""
+    values = np.asarray(value)
+    if values.ndim == 0:
+        return np.repeat(values, nentry)
+    values = values.ravel()
+    if values.size == nentry:
+        return values
+    # a per-location value is repeated for every time the measure is taken;
+    # with one time the two lengths are the same and either reading holds
+    if values.size == nloc:
+        return values[at_loc]
+    raise Exception(
+        f"column `{name}` has {values.size} values, and the measure has "
+        f"{nloc} locations and {nentry} entries"
+    )
+
+
+def _ascii_lines(grid: str, columns: dict[str, np.ndarray]):
+    """Yield the entry lines of one measure, one-based as the file is."""
+    names = (*TIME_COLUMNS, *LOCATION_COLUMNS[grid])
+    template = "  " + " ".join(["%d"] * len(names)) + " %s %s %r %r\n"
+
+    # tolist gives python scalars, so %r writes a float that reads back
+    # exactly and a string without the numpy wrapper
+    values = [(columns[name] + 1).tolist() for name in names]
+    values += [columns[name].tolist() for name in VALUE_COLUMNS]
+    for row in zip(*values):
+        yield template % row
+
+
+def _write_ascii(path, measures, options) -> None:
+    """Write measures as an adjoint input file."""
+    with open(path, "w") as f:
+        if options:
+            f.write("begin options\n")
+            for key, value in options.items():
+                f.write(f"  {key} {value}\n")
+            f.write("end options\n\n")
+        for name, (grid, columns) in measures.items():
+            f.write(f"begin performance_measure {name}\n")
+            f.writelines(_ascii_lines(grid, columns))
+            f.write("end performance_measure\n\n")
+
+
+def _write_hdf5(path, measures, options) -> None:
+    """Write measures as an hdf5 file, one dataset per column."""
+    import h5py
+
+    with h5py.File(path, "w") as hf:
+        hf.attrs["mf6adj_pm_version"] = 1
+        for key, value in (options or {}).items():
+            hf.attrs[key] = str(value)
+        for name, (grid, columns) in measures.items():
+            group = hf.create_group(f"performance_measures/{name}")
+            group.attrs["discretization"] = grid
+            for column, values in columns.items():
+                # a column of names is held as fixed-length bytes, which
+                # compress; the variable-length form carries a pointer and a
+                # heap entry per value and is larger than the ascii file
+                if values.dtype.kind in "US":
+                    values = values.astype("S")
+                group.create_dataset(
+                    column, data=values, compression="gzip", compression_opts=4
+                )
+
+
+def write_performance_measures(
+    path: PathLike,
+    measures: dict[str, Any],
+    options: Optional[dict[str, Any]] = None,
+    format: str = "ascii",
+) -> pl.Path:
+    """Write performance measures as an adjoint input file.
+
+    Parameters
+    ----------
+    path : PathLike
+        File to write.
+    measures : dict
+        Measure name to its columns, given as a dict, a numpy recarray, or a
+        dataframe. Locations are `cellid`, or the index columns of the
+        discretization; times are `kper` and `kstp`; values are `pm_type`,
+        `pm_form`, `weight`, and `obsval`. Indices are zero-based.
+    options : dict, optional
+        Options block, such as ``{"hdf5_name": "out.h5"}``.
+    format : str
+        ``ascii``, which is the format MODFLOW 6 input is written in and the
+        default, or ``hdf5``, which is about nine times smaller.
+
+    Returns
+    -------
+    pathlib.Path
+        The file written.
+    """
+    if format not in ("ascii", "hdf5"):
+        raise Exception(f"format is `ascii` or `hdf5`, not `{format}`")
+    if not measures:
+        raise Exception("no performance measures to write")
+
+    prepared = {name: normalize(measure) for name, measure in measures.items()}
+
+    grids = {grid for grid, _ in prepared.values()}
+    if len(grids) > 1:
+        raise Exception(
+            f"the measures are not all on the same discretization: {sorted(grids)}"
+        )
+
+    path = pl.Path(path)
+    if format == "ascii":
+        _write_ascii(path, prepared, options)
+    else:
+        _write_hdf5(path, prepared, options)
+    return path
+
+
+def is_hdf5(path: PathLike) -> bool:
+    """Return whether a file is hdf5, by its signature rather than its name."""
+    path = pl.Path(path)
+    if not path.is_file():
+        return False
+    with open(path, "rb") as f:
+        return f.read(8) == b"\x89HDF\r\n\x1a\n"
+
+
+def _read_ascii(path) -> tuple[dict[str, dict[str, np.ndarray]], dict]:
+    """Read an adjoint input file into columns, without a model to resolve nodes."""
+    measures: dict[str, dict[str, np.ndarray]] = {}
+    options: dict[str, Any] = {}
+
+    block = None
+    rows: list[list[str]] = []
+    with open(path) as f:
+        for line in f:
+            stripped = line.strip()
+            if not stripped or stripped.startswith("#"):
+                continue
+            lowered = stripped.lower()
+
+            if lowered.startswith("begin options"):
+                block = "options"
+            elif lowered.startswith("begin performance_measure"):
+                block, rows = lowered.split()[2], []
+            elif lowered.startswith("end options"):
+                block = None
+            elif lowered.startswith("end performance_measure"):
+                measures[block] = _columns_from_rows(rows)
+                block, rows = None, []
+            elif block == "options":
+                key, value = lowered.split(maxsplit=1)
+                options[key] = value
+            elif block is None:
+                raise Exception(f"line outside a block: '{stripped}'")
+            else:
+                rows.append(lowered.split())
+
+    if block is not None:
+        raise EOFError(f"end of file while reading block '{block}'")
+    return measures, options
+
+
+def _columns_from_rows(rows) -> dict[str, np.ndarray]:
+    """Return the entry lines of one measure as zero-based columns."""
+    if not rows:
+        raise Exception("a performance measure holds no entries")
+
+    widths = {len(row) for row in rows}
+    if len(widths) != 1:
+        raise Exception(f"the entries do not all have the same width: {sorted(widths)}")
+
+    width = widths.pop()
+    grid = {9: "dis", 8: "disv", 7: "disu"}.get(width)
+    if grid is None:
+        raise Exception(f"an entry holds 7, 8, or 9 items, not {width}")
+
+    names = (*TIME_COLUMNS, *LOCATION_COLUMNS[grid])
+    values = list(zip(*rows))
+    columns = {
+        name: np.array(values[idx], dtype=np.int64) - 1
+        for idx, name in enumerate(names)
+    }
+    columns["pm_type"] = np.array(values[-4])
+    columns["pm_form"] = np.array(values[-3])
+    columns["weight"] = np.array(values[-2], dtype=float)
+    columns["obsval"] = np.array(values[-1], dtype=float)
+    return columns
+
+
+def _read_hdf5(path) -> tuple[dict[str, dict[str, np.ndarray]], dict]:
+    """Read an hdf5 performance-measure file into columns."""
+    import h5py
+
+    measures: dict[str, dict[str, np.ndarray]] = {}
+    with h5py.File(path, "r") as hf:
+        options = {
+            key: value for key, value in hf.attrs.items() if key != "mf6adj_pm_version"
+        }
+        for name, group in hf.get("performance_measures", {}).items():
+            columns = {}
+            for column, dataset in group.items():
+                values = dataset[:]
+                if values.dtype.kind == "O":
+                    values = np.array([v.decode() for v in values])
+                elif values.dtype.kind == "S":
+                    values = np.char.decode(values)
+                columns[column] = values
+            measures[name] = columns
+    return measures, options
+
+
+def read_performance_measures(
+    path: PathLike,
+) -> tuple[dict[str, dict[str, np.ndarray]], dict]:
+    """Read performance measures from an adjoint input file, ascii or hdf5.
+
+    The format is taken from the file itself rather than its name.
+
+    Parameters
+    ----------
+    path : PathLike
+        File to read.
+
+    Returns
+    -------
+    tuple[dict, dict]
+        Measure name to its zero-based columns, and the options block. The
+        measures are in the form `write_performance_measures` accepts, so a
+        file read here can be written back in either format.
+    """
+    path = pl.Path(path)
+    if not path.is_file():
+        raise FileNotFoundError(f"performance measure file not found: {path}")
+    return _read_hdf5(path) if is_hdf5(path) else _read_ascii(path)


### PR DESCRIPTION
A performance measure had no writer, so every caller built the file with `f.write` by hand — about 20 files in `autotest` and 8 notebooks, each reimplementing the format.

`write_performance_measures` takes the measures as a dict of columns, a numpy recarray, or a dataframe, so cell identifiers come straight from flopy, and writes ascii or hdf5. `read_performance_measures` reads either and returns what the writer accepts. `Mf6Adj` reads an hdf5 measure too, dispatching on the file rather than its name, so one can be solved and not only stored. Ascii is the default.

Times are given either as `times`, an axis crossed with the locations, or as `kper` and `kstp`, one value per entry. Keeping the two apart is what lets a measure read from a file be written back unchanged. `all_times` builds the pairs for periods holding different numbers of time steps, which no cross of two axes gives.

At 2,358,895 entries, one per active cell of a CONUS subdomain:

| | ascii | hdf5 |
| --- | --- | --- |
| write | 1.3 s | 1.0 s |
| read | 8.0 s | 0.6 s |
| size | 93.8 MB | 12.2 MB |

Held as variable-length strings the names made the hdf5 file 200 MB, larger than the ascii it replaces; fixed-length bytes compress. `test_hdf5_is_smaller` guards that.

Verified by solving one model from a hand-written file, a written file, and an hdf5 file, which agree across all sensitivities.

The ascii path still scans every node per entry; the vectorized `map_reduced_nodes` added here makes #134 a small follow-up. Converting the existing tests and notebooks to the utility is left for its own change.

Closes #133
