### PR TITLE
fix(pm): map a measure onto the reduced nodes without scanning the model

### DIFF
--- a/autotest/test_reduced_nodes.py
+++ b/autotest/test_reduced_nodes.py
@@ -1,0 +1,184 @@
+"""
+Tests for mapping a performance measure onto a reduced node numbering.
+
+MODFLOW 6 omits inactive cells from its internal node numbering, so a measure
+given in grid indices has to be mapped onto the nodes the model actually holds.
+The map is built once for a file; searching NODEUSER for each entry is one pass
+over the model per entry, which is minutes on a model of a few million cells.
+
+Cases:
+  - test_map_matches_the_scan   : the map gives what searching NODEUSER gives.
+  - test_no_reduction           : a model that omits nothing maps to itself.
+  - test_node_outside_the_map   : a node the model does not hold is reported.
+  - test_solves_on_a_reduced_model : a measure on a model with inactive cells
+                                  reproduces a perturbation of the same model.
+  - test_measure_on_an_inactive_cell : a measure on an omitted cell is refused.
+"""
+
+import pathlib as pl
+import shutil
+import sys
+
+import flopy
+import numpy as np
+import pytest
+
+try:
+    import mf6adj
+except ImportError:
+    sys.path.insert(0, str(pl.Path("../").resolve()))
+    import mf6adj
+
+from mf6adj.utils.utils_pm_read import (
+    build_reduced_map,
+    map_reduced_node,
+    map_reduced_nodes,
+)
+
+mf6_bin, lib_name = mf6adj.get_conda_mf6_paths()
+
+NAME = "reduced"
+NLAY, NROW, NCOL = 1, 5, 5
+INACTIVE = [(0, 1, 1), (0, 2, 2)]
+OBS = (0, 3, 3)
+
+
+def scan(inode, nuser):
+    """The mapping as it was done before, one pass over the model per entry."""
+    return int(np.where(nuser == inode)[0][0])
+
+
+def test_map_matches_the_scan():
+    """The map gives, for every node, what searching NODEUSER gives."""
+    rng = np.random.default_rng(0)
+    nuser = np.sort(rng.choice(5_000, size=4_000, replace=False))
+
+    reduced = build_reduced_map(nuser)
+    assert reduced is not None
+
+    for inode in nuser[:: len(nuser) // 50]:
+        assert map_reduced_node(int(inode), reduced) == scan(int(inode), nuser)
+
+    assert np.array_equal(map_reduced_nodes(nuser, reduced), np.arange(nuser.size))
+    picks = rng.choice(nuser, size=200, replace=False)
+    assert np.array_equal(
+        map_reduced_nodes(picks, reduced), [scan(int(n), nuser) for n in picks]
+    )
+
+
+def test_no_reduction():
+    """A model that omits nothing has no map, and a node is already its own."""
+    assert build_reduced_map(np.array([0])) is None
+    assert map_reduced_node(17, None) == 17
+    assert np.array_equal(map_reduced_nodes(np.arange(5), None), np.arange(5))
+
+
+def test_node_outside_the_map():
+    """A node the model does not hold is reported rather than mapped."""
+    nuser = np.array([0, 1, 3, 4])
+    reduced = build_reduced_map(nuser)
+
+    assert map_reduced_node(3, reduced) == 2
+    with pytest.raises(Exception, match="not in reduced node num"):
+        map_reduced_node(2, reduced)
+    with pytest.raises(Exception, match="not in reduced node num"):
+        map_reduced_node(99, reduced)
+    with pytest.raises(Exception, match="not in reduced node num"):
+        map_reduced_nodes(np.array([0, 2]), reduced)
+    with pytest.raises(Exception, match="not in reduced node num"):
+        map_reduced_nodes(np.array([0, 99]), reduced)
+
+
+def _build(ws, cell):
+    """A confined model with two inactive cells, measured at one cell."""
+    ws = pl.Path(ws)
+    if ws.exists():
+        shutil.rmtree(ws)
+    ws.mkdir(parents=True)
+
+    idomain = np.ones((NLAY, NROW, NCOL), dtype=int)
+    for k, i, j in INACTIVE:
+        idomain[k, i, j] = 0
+
+    sim = flopy.mf6.MFSimulation(sim_name=NAME, sim_ws=str(ws), exe_name=mf6_bin)
+    flopy.mf6.ModflowTdis(sim, nper=1, perioddata=[(1.0, 1, 1.0)])
+    flopy.mf6.ModflowIms(sim, complexity="simple")
+    gwf = flopy.mf6.ModflowGwf(sim, modelname=NAME, save_flows=True)
+    flopy.mf6.ModflowGwfdis(
+        gwf,
+        nlay=NLAY,
+        nrow=NROW,
+        ncol=NCOL,
+        delr=10.0,
+        delc=10.0,
+        top=10.0,
+        botm=0.0,
+        idomain=idomain,
+    )
+    flopy.mf6.ModflowGwfic(gwf, strt=5.0)
+    flopy.mf6.ModflowGwfnpf(gwf, icelltype=0, k=10.0)
+    flopy.mf6.ModflowGwfchd(
+        gwf,
+        stress_period_data=[[(0, i, 0), 6.0] for i in range(NROW)]
+        + [[(0, i, NCOL - 1), 4.0] for i in range(NROW)],
+        pname="chd-1",
+    )
+    flopy.mf6.ModflowGwfoc(
+        gwf, head_filerecord=f"{NAME}.hds", saverecord=[("HEAD", "ALL")]
+    )
+    sim.write_simulation(silent=True)
+    success, buff = sim.run_simulation(silent=True)
+    assert success, "\n".join(buff[-20:])
+
+    k, i, j = cell
+    with open(ws / "pm.dat", "w") as f:
+        f.write("begin performance_measure obs\n")
+        f.write(f"  1 1 {k + 1} {i + 1} {j + 1} head direct 1.0 -1.0e+30\n")
+        f.write("end performance_measure\n\n")
+    return ws
+
+
+def test_solves_on_a_reduced_model(function_tmpdir):
+    """A measure on a model with inactive cells matches a perturbation of it.
+
+    The perturbation reruns the model for each parameter and does not use the
+    map, so agreeing with it is what shows the entry was mapped onto the node
+    the model actually solved.
+    """
+    ws = _build(function_tmpdir / "solve", OBS)
+
+    adj = mf6adj.Mf6Adj(
+        "pm.dat", lib_name, logging_level="ERROR", working_directory=str(ws)
+    )
+    adj.solve_forward_model(hdf5_name="fwd.hd5")
+    df = adj.solve_adjoint()
+    pert = adj.perturbation_method(pert_mult=1.0001)
+    adj.finalize()
+
+    # the results are in the model's own node space, which omits the two cells
+    nactive = NLAY * NROW * NCOL - len(INACTIVE)
+    assert len(df["obs"]) == nactive
+    assert df["obs"]["k11"].notna().all()
+
+    omitted = {(i, j) for _, i, j in INACTIVE}
+    assert not omitted & set(zip(pert["i"], pert["j"]))
+
+    adjoint = df["obs"]["k11"].to_numpy()
+    finite = pert.loc[pert.addr == "k11_reduced_npf", "obs"].to_numpy()
+    assert finite.size == nactive
+
+    # a forward difference carries its own truncation error, so the comparison
+    # is loose where the sensitivity is not near zero
+    resolved = np.abs(adjoint) > 1.0e-8
+    assert resolved.sum() > nactive // 2
+    assert np.allclose(adjoint[resolved], finite[resolved], rtol=0.01)
+    assert np.allclose(adjoint[~resolved], finite[~resolved], atol=1.0e-6)
+
+
+def test_measure_on_an_inactive_cell(function_tmpdir):
+    """A measure on a cell the model omits is refused rather than mapped."""
+    ws = _build(function_tmpdir / "inactive", INACTIVE[0])
+    with pytest.raises(Exception, match="not in reduced node num"):
+        mf6adj.Mf6Adj(
+            "pm.dat", lib_name, logging_level="ERROR", working_directory=str(ws)
+        )

--- a/mf6adj/utils/utils_pm_read.py
+++ b/mf6adj/utils/utils_pm_read.py
@@ -144,10 +144,14 @@ def read_adj_file(
     """
     hdf5_name = None if current_hdf5_name is None else pl.Path(current_hdf5_name)
 
+    # built once for the file; searching NODEUSER for each entry is one pass
+    # over the model per entry
+    reduced = build_reduced_map(nuser)
+
     if is_hdf5(adj_filename):
         return read_adj_hdf5(
             adj_filename,
-            nuser,
+            reduced,
             nstp,
             nper,
             ncpl,
@@ -185,7 +189,7 @@ def read_adj_file(
                     f,
                     line,
                     count,
-                    nuser,
+                    reduced,
                     nstp,
                     nper,
                     ncpl,
@@ -354,24 +358,47 @@ def validate_pm_type(
         )
 
 
+def build_reduced_map(nuser: np.ndarray) -> Optional[np.ndarray]:
+    """Return the inverse of ``NODEUSER``, or None when nodes are not reduced.
+
+    MODFLOW 6 omits inactive cells from its internal node numbering, and
+    ``NODEUSER`` gives the full-grid node of each reduced one. The inverse is
+    built once for a file rather than searched for each entry, which would be
+    one pass over the model per entry.
+
+    Parameters
+    ----------
+    nuser : ndarray
+        Zero-based ``NODEUSER`` array from MODFLOW 6.
+
+    Returns
+    -------
+    ndarray or None
+        Reduced node of each full-grid node, -1 where there is none, or None
+        when the model does not reduce its nodes.
+    """
+    if len(nuser) <= 1:
+        return None
+
+    inverse = np.full(int(nuser.max()) + 1, -1, dtype=np.int64)
+    inverse[nuser] = np.arange(nuser.size, dtype=np.int64)
+    return inverse
+
+
 def map_reduced_node(
     inode: int,
-    nuser: np.ndarray,
+    reduced: Optional[np.ndarray],
     kij: Optional[list[int]] = None,
     logger=None,
 ) -> int:
     """Map a full-grid node number to the reduced MODFLOW 6 node index.
 
-    MODFLOW 6 may omit inactive cells from internal node numbering. This
-    helper converts a full-grid node number into the corresponding index in
-    the reduced node list used by the API.
-
     Parameters
     ----------
     inode : int
         Zero-based full-grid node number.
-    nuser : ndarray
-        Zero-based ``NODEUSER`` array from MODFLOW 6.
+    reduced : ndarray or None
+        Map from `build_reduced_map`, or None when nodes are not reduced.
     kij : list[int], optional
         Structured-grid layer-row-column indices used only for additional
         debug context when a mapping fails.
@@ -383,22 +410,22 @@ def map_reduced_node(
     int
         Zero-based reduced node index.
     """
-    if len(nuser) <= 1:
+    if reduced is None:
         return inode
 
-    nn = np.where(nuser == inode)[0]
-    if nn.shape[0] != 1:
+    node = -1 if inode > reduced.size - 1 else int(reduced[inode])
+    if node < 0:
         if logger is not None:
-            logger.info(f"{nuser} {nn}")
+            logger.info(f"{inode}")
             if kij is not None:
                 logger.info(f"{kij}")
         raise Exception(f"node num {inode} not in reduced node num")
-    return int(nn[0])
+    return node
 
 
 def map_reduced_nodes(
     inodes: np.ndarray,
-    nuser: np.ndarray,
+    reduced: Optional[np.ndarray],
     logger=None,
 ) -> np.ndarray:
     """Map full-grid node numbers to the reduced MODFLOW 6 node indices.
@@ -407,8 +434,8 @@ def map_reduced_nodes(
     ----------
     inodes : ndarray
         Zero-based full-grid node numbers.
-    nuser : ndarray
-        Zero-based ``NODEUSER`` array from MODFLOW 6.
+    reduced : ndarray or None
+        Map from `build_reduced_map`, or None when nodes are not reduced.
     logger : logging.Logger, optional
         Optional logger used to emit debug context before raising.
 
@@ -418,28 +445,24 @@ def map_reduced_nodes(
         Zero-based reduced node indices.
     """
     inodes = np.asarray(inodes, dtype=np.int64)
-    if len(nuser) <= 1:
+    if reduced is None:
         return inodes
 
-    # the inverse of nuser, built once, so a lookup does not scan the model
-    inverse = np.full(int(nuser.max()) + 1, -1, dtype=np.int64)
-    inverse[nuser] = np.arange(nuser.size, dtype=np.int64)
-
-    outside = inodes > inverse.size - 1
-    reduced = np.where(outside, -1, inverse[np.where(outside, 0, inodes)])
-    missing = reduced < 0
+    outside = inodes > reduced.size - 1
+    nodes = np.where(outside, -1, reduced[np.where(outside, 0, inodes)])
+    missing = nodes < 0
     if missing.any():
         if logger is not None:
             logger.info(f"{inodes[missing]}")
         raise Exception(f"node num {int(inodes[missing][0])} not in reduced node num")
-    return reduced
+    return nodes
 
 
 def parse_pm_location(
     raw: list[str],
     count: int,
     line2: str,
-    nuser: np.ndarray,
+    reduced: Optional[np.ndarray],
     ncpl: Optional[int],
     is_structured: bool,
     unstructured_type: Optional[str],
@@ -462,8 +485,8 @@ def parse_pm_location(
         Source line number used in error messages.
     line2 : str
         Raw source line used in error messages.
-    nuser : ndarray
-        Zero-based ``NODEUSER`` array from MODFLOW 6.
+    reduced : ndarray or None
+        Map from `build_reduced_map`, or None when nodes are not reduced.
     ncpl : int, optional
         Number of cells per layer for ``DISV`` and ``DISU`` parsing.
     is_structured : bool
@@ -496,7 +519,7 @@ def parse_pm_location(
                 )
         k, i, j = kij[0], kij[1], kij[2]
         inode = get_node(shape, [kij])[0]
-        inode = map_reduced_node(inode, nuser, kij=kij, logger=logger)
+        inode = map_reduced_node(inode, reduced, kij=kij, logger=logger)
         return inode, k, i, j
 
     if unstructured_type == "disv":
@@ -517,7 +540,7 @@ def parse_pm_location(
         if ncpl is None:
             raise Exception("ncpl is None for disv parsing")
         inode = ((ncpl * (lay - 1)) + node) - 1
-        inode = map_reduced_node(inode, nuser, kij=None, logger=logger)
+        inode = map_reduced_node(inode, reduced, kij=None, logger=logger)
         return inode, k, i, j
 
     if unstructured_type == "disu":
@@ -525,7 +548,7 @@ def parse_pm_location(
             inode = int(raw[2]) - 1
         except Exception as e:
             print(f"{e}\n\nerror casting node info on line {count}: '{line2}'")
-        inode = map_reduced_node(inode, nuser, kij=None, logger=logger)
+        inode = map_reduced_node(inode, reduced, kij=None, logger=logger)
         return inode, k, i, j
 
     raise Exception(
@@ -588,7 +611,7 @@ def parse_performance_measure_block(
     f,
     line: str,
     count: int,
-    nuser: np.ndarray,
+    reduced: Optional[np.ndarray],
     nstp: np.ndarray,
     nper: int,
     ncpl: Optional[int],
@@ -609,8 +632,8 @@ def parse_performance_measure_block(
         The `begin performance_measure ...` line.
     count : int
         Current source-line counter.
-    nuser : ndarray
-        Reduced-node user mapping.
+    reduced : ndarray or None
+        Map from `build_reduced_map`, or None when nodes are not reduced.
     nstp : ndarray
         Number of time steps per stress period.
     nper : int
@@ -684,7 +707,7 @@ def parse_performance_measure_block(
             raw,
             count,
             line2,
-            nuser,
+            reduced,
             ncpl,
             is_structured,
             unstructured_type,
@@ -718,7 +741,7 @@ def parse_performance_measure_block(
 
 def read_adj_hdf5(
     adj_filename: PathLike,
-    nuser: np.ndarray,
+    reduced: Optional[np.ndarray],
     nstp: np.ndarray,
     nper: int,
     ncpl: Optional[int],
@@ -740,8 +763,8 @@ def read_adj_hdf5(
     ----------
     adj_filename : PathLike
         Adjoint input filename.
-    nuser : ndarray
-        Reduced-node user mapping.
+    reduced : ndarray or None
+        Map from `build_reduced_map`, or None when nodes are not reduced.
     nstp : ndarray
         Number of time steps per stress period.
     nper : int
@@ -810,7 +833,7 @@ def read_adj_hdf5(
             )
         else:
             inode = np.asarray(columns["node"], dtype=np.int64)
-        inode = map_reduced_nodes(inode, nuser, logger=logger)
+        inode = map_reduced_nodes(inode, reduced, logger=logger)
 
         for pm_type in np.unique(columns["pm_type"]):
             validate_pm_type(


### PR DESCRIPTION
Stacked on #135, which adds the vectorized mapping this uses. Review that one first; the diff here is against it.

A performance measure given in grid indices was mapped onto the model's node numbering by searching `NODEUSER` for each entry, which is one pass over every node in the model per entry.

This is the setup phase reported in #132. Timed on those models, the search is 556 us per entry against 1.06 us for the rest of the location parsing, which is 262 s at 471,779 entries on a 2,375,722-node model. The inverse of `NODEUSER`, built once for the file, does it in 3.3 ms and 26 MB:

| 100,000 entries, 2.4M nodes | |
| --- | --- |
| the search it replaces | 53.7 s |
| the map | 0.36 s |

A model that does not reduce its nodes is unaffected either way, since `NODEUSER` has length one there and the mapping returns immediately. A node the model does not hold is still reported rather than mapped to something else.

Verified against `perturbation_method` on a model with two `IDOMAIN=0` cells. The perturbation reruns the model for each parameter and does not use the map, so agreeing with it is what shows the entry reached the node the model solved. They agree to 0.15%, which is the truncation error of the forward difference, and both omit the inactive cells.

Closes #134