### PR TITLE
docs: point the documentation links at the site that serves them

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -4,7 +4,7 @@ title: "mf6adj"
 version: 1.3.0
 license: CC0-1.0
 repository-code: "https://github.com/INTERA-Inc/mf6adj"
-url: "https://mf6adj.readthedocs.io"
+url: "https://md6adj.readthedocs.io"
 
 authors:
   - family-names: Hayek

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ print(sensitivity_dfs["head_obs"])
 ## Documentation
 
 Full documentation, including API reference and example notebooks, is available
-at [mf6adj.readthedocs.io](https://md6adj.readthedocs.io).
+at [md6adj.readthedocs.io](https://md6adj.readthedocs.io).
 
 ## How to cite
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ doc = [
 ]
 
 [project.urls]
-Documentation = "https://mf6adj.readthedocs.io"
+Documentation = "https://md6adj.readthedocs.io"
 "Bug Tracker" = "https://github.com/INTERA-Inc/mf6adj/issues"
 "Source Code" = "https://github.com/INTERA-Inc/mf6adj"
 


### PR DESCRIPTION
The Read the Docs project is named `md6adj`, and three links spelled it `mf6adj`.

`https://mf6adj.readthedocs.io` returns 404; `https://md6adj.readthedocs.io` serves the docs.

- `pyproject.toml` — this is the **Documentation** link PyPI shows, so it is broken on the [1.3.0 release page](https://pypi.org/project/mf6adj/) as published.
- `CITATION.cff` — same URL, same 404.
- `README.md` — the href was already right, but the link text read `mf6adj.readthedocs.io`.

Read the Docs does not rename a project slug, so the links move to it rather than the other way round. Renaming would mean a new project at `mf6adj` with the old one left as a redirect, which is a separate decision.

The conda-forge recipe already points at `md6adj` and needs no change.