### PR TITLE
feat(pm): report an adjoint matrix that cannot carry a sensitivity

### DIFF
--- a/autotest/test_conditioning.py
+++ b/autotest/test_conditioning.py
@@ -1,0 +1,298 @@
+"""
+Tests the report on an adjoint matrix that cannot carry a sensitivity.
+
+The adjoint is solved against the matrix MODFLOW 6 assembled. A row whose
+diagonal has fallen away still solves, and the state it returns goes as one
+over that diagonal, so a measure can come back with values far larger than the
+flow model supports and nothing says why.
+
+The checks are the ones affordable at model scale: the diagonal, which is one
+pass, and the residual of the solve, which is one matrix-vector product.
+
+Cases:
+  - test_sound_matrix_is_quiet   : a well formed matrix reports nothing.
+  - test_row_with_no_diagonal    : a singular row is counted and named.
+  - test_small_diagonal          : a row far below the rest is counted.
+  - test_worst_rows_are_named    : the report names the smallest diagonals.
+  - test_residual_is_relative    : the residual is scaled by the right side.
+  - test_healthy_model_is_quiet  : a real solve warns about nothing.
+  - test_isolated_cell_is_reported : a solve whose matrix holds a row far
+                                   below the rest names the cell.
+  - test_dry_cells_are_not_reported : cells that go dry under the
+                                   Newton-Raphson formulation are not such
+                                   rows, and are not reported.
+"""
+
+import pathlib as pl
+import shutil
+import sys
+
+import flopy
+import numpy as np
+import scipy.sparse as sps
+
+try:
+    import mf6adj
+except ImportError:
+    sys.path.insert(0, str(pl.Path("../").resolve()))
+    import mf6adj
+
+from mf6adj.utils.utils_conditioning import (
+    describe,
+    diagonal_report,
+    solve_residual,
+)
+
+mf6_bin, lib_name = mf6adj.get_conda_mf6_paths()
+
+
+def _matrix(diagonal):
+    """A matrix with the given diagonal and a little off-diagonal weight."""
+    n = len(diagonal)
+    mat = sps.lil_matrix((n, n))
+    for i, d in enumerate(diagonal):
+        mat[i, i] = d
+        if i + 1 < n:
+            mat[i, i + 1] = -1.0
+    return mat.tocsr()
+
+
+def test_sound_matrix_is_quiet():
+    """Every row supporting a solution reports nothing."""
+    assert diagonal_report(_matrix([10.0, 11.0, 9.5, 10.5])) is None
+    # a spread of two orders is still sound
+    assert diagonal_report(_matrix([100.0, 10.0, 1.0])) is None
+
+
+def test_row_with_no_diagonal():
+    """A singular row is counted."""
+    report = diagonal_report(_matrix([10.0, 0.0, 10.0]))
+    assert report is not None
+    assert report["nzero"] == 1
+    assert report["nsmall"] == 0
+    assert 1 in [int(r) for r in report["rows"]]
+
+
+def test_small_diagonal():
+    """A row far below the rest of the model is counted, and is not singular."""
+    report = diagonal_report(_matrix([10.0, 10.0, 1.0e-9, 10.0]))
+    assert report is not None
+    assert report["nzero"] == 0
+    assert report["nsmall"] == 1
+    assert np.isclose(report["median"], 10.0)
+
+
+def test_worst_rows_are_named():
+    """The message names the smallest diagonals, smallest first."""
+    report = diagonal_report(_matrix([10.0, 1.0e-12, 10.0, 1.0e-9, 10.0]))
+    assert [int(r) for r in report["rows"]][:2] == [1, 3]
+    message = describe(report, kper=2, kstp=3)
+    assert "stress period 3" in message and "time step 4" in message
+    assert "1" in message
+
+
+def test_residual_is_relative():
+    """The residual is scaled by the right-hand side it was solved against."""
+    mat = _matrix([2.0, 2.0, 2.0])
+    rhs = np.array([2.0, 2.0, 2.0])
+    exact = sps.linalg.spsolve(mat.tocsc(), rhs)
+    assert solve_residual(mat, exact, rhs) < 1.0e-12
+
+    # a solution that is out by one unit against a right side of two
+    assert np.isclose(solve_residual(mat, np.zeros(3), rhs), 1.0)
+
+
+def test_healthy_model_is_quiet(function_tmpdir, caplog):
+    """A model whose cells stay wet warns about neither rows nor residual."""
+    ws = pl.Path(function_tmpdir) / "quiet"
+    if ws.exists():
+        shutil.rmtree(ws)
+    ws.mkdir(parents=True)
+
+    sim = flopy.mf6.MFSimulation(sim_name="q", sim_ws=str(ws), exe_name=mf6_bin)
+    flopy.mf6.ModflowTdis(sim, nper=2, perioddata=[(10.0, 2, 1.0)] * 2)
+    flopy.mf6.ModflowIms(sim, complexity="simple")
+    gwf = flopy.mf6.ModflowGwf(sim, modelname="q", save_flows=True)
+    flopy.mf6.ModflowGwfdis(
+        gwf, nlay=1, nrow=1, ncol=8, delr=100.0, delc=100.0, top=10.0, botm=0.0
+    )
+    flopy.mf6.ModflowGwfic(gwf, strt=9.0)
+    flopy.mf6.ModflowGwfnpf(gwf, icelltype=0, k=10.0)
+    flopy.mf6.ModflowGwfsto(gwf, iconvert=0, ss=1.0e-5, transient={0: True})
+    flopy.mf6.ModflowGwfchd(
+        gwf, stress_period_data=[[(0, 0, 0), 9.0], [(0, 0, 7), 8.0]], pname="chd-1"
+    )
+    flopy.mf6.ModflowGwfoc(gwf, head_filerecord="q.hds", saverecord=[("HEAD", "ALL")])
+    sim.write_simulation(silent=True)
+    success, buff = sim.run_simulation(silent=True)
+    assert success, "\n".join(buff[-20:])
+
+    with open(ws / "pm.dat", "w") as f:
+        f.write("begin performance_measure obs\n")
+        f.write("  2 2 1 1 4 head direct 1.0 -1.0e+30\n")
+        f.write("end performance_measure\n")
+
+    with caplog.at_level("WARNING"):
+        adj = mf6adj.Mf6Adj(
+            "pm.dat", lib_name, logging_level="WARNING", working_directory=str(ws)
+        )
+        adj.solve_forward_model(hdf5_name="fwd.hd5")
+        adj.solve_adjoint()
+        adj.finalize()
+
+    noise = [
+        r.message
+        for r in caplog.records
+        if "diagonal" in r.message or "residual" in r.message
+    ]
+    assert not noise, f"a sound model reported {noise}"
+
+
+def test_isolated_cell_is_reported(function_tmpdir, caplog):
+    """A cell the model barely connects to is named, with its diagonal.
+
+    Its conductances set the diagonal of its row, so a conductivity far below
+    the rest of the model leaves a row whose state goes as one over almost
+    nothing. The flow model solves without trouble, which is the point: there
+    is nothing else to notice it by.
+    """
+    ws = pl.Path(function_tmpdir) / "isolated"
+    if ws.exists():
+        shutil.rmtree(ws)
+    ws.mkdir(parents=True)
+
+    k = np.full((1, 1, 10), 10.0)
+    k[0, 0, 5] = 1.0e-11
+
+    sim = flopy.mf6.MFSimulation(sim_name="iso", sim_ws=str(ws), exe_name=mf6_bin)
+    flopy.mf6.ModflowTdis(sim, nper=1, perioddata=[(1.0, 1, 1.0)])
+    flopy.mf6.ModflowIms(sim, complexity="simple", outer_maximum=200)
+    gwf = flopy.mf6.ModflowGwf(sim, modelname="iso", save_flows=True)
+    flopy.mf6.ModflowGwfdis(
+        gwf, nlay=1, nrow=1, ncol=10, delr=100.0, delc=100.0, top=10.0, botm=0.0
+    )
+    flopy.mf6.ModflowGwfic(gwf, strt=9.0)
+    flopy.mf6.ModflowGwfnpf(gwf, icelltype=0, k=k)
+    flopy.mf6.ModflowGwfsto(gwf, iconvert=0, ss=1.0e-5, steady_state={0: True})
+    flopy.mf6.ModflowGwfchd(
+        gwf, stress_period_data=[[(0, 0, 0), 9.0], [(0, 0, 9), 8.0]], pname="chd-1"
+    )
+    flopy.mf6.ModflowGwfoc(gwf, head_filerecord="iso.hds", saverecord=[("HEAD", "ALL")])
+    sim.write_simulation(silent=True)
+    success, buff = sim.run_simulation(silent=True)
+    assert success, "the flow model is expected to solve\n" + "\n".join(buff[-20:])
+
+    with open(ws / "pm.dat", "w") as f:
+        f.write("begin performance_measure obs\n")
+        f.write("  1 1 1 1 3 head direct 1.0 -1.0e+30\n")
+        f.write("end performance_measure\n")
+
+    with caplog.at_level("WARNING"):
+        adj = mf6adj.Mf6Adj(
+            "pm.dat", lib_name, logging_level="WARNING", working_directory=str(ws)
+        )
+        adj.solve_forward_model(hdf5_name="fwd.hd5")
+        adj.solve_adjoint()
+        adj.finalize()
+
+    reported = [r.message for r in caplog.records if "diagonal" in r.message]
+    assert reported, "the row far below the rest was not reported"
+    assert "5" in reported[0], reported[0]
+
+
+def test_dry_cells_are_not_reported(function_tmpdir, caplog):
+    """A cell that goes dry is not a row that has fallen away.
+
+    Drying was the reason first given for this report and it is the wrong one.
+    A drain moved from the upper layer into the lower one empties the upper
+    layer, and MODFLOW 6 gives a dry cell a diagonal of its own rather than
+    letting it fall to nothing. The sensitivities stay small, so nothing here
+    is reported, and a large sensitivity on such a model has another cause.
+    """
+    ws = pl.Path(function_tmpdir) / "dry"
+    if ws.exists():
+        shutil.rmtree(ws)
+    ws.mkdir(parents=True)
+
+    ncol, top, mid, bot, chd = 8, 20.0, 10.0, 0.0, 18.0
+    # the drain starts high in the upper layer and finishes low in the lower one
+    schedule = [
+        (0, 18.0),
+        (0, 15.0),
+        (0, 12.0),
+        (0, 10.5),
+        (1, 9.0),
+        (1, 5.0),
+        (1, 1.0),
+        (1, 0.05),
+    ]
+
+    sim = flopy.mf6.MFSimulation(sim_name="dry", sim_ws=str(ws), exe_name=mf6_bin)
+    flopy.mf6.ModflowTdis(
+        sim, nper=len(schedule), perioddata=[(5000.0, 2, 1.0)] * len(schedule)
+    )
+    flopy.mf6.ModflowIms(
+        sim,
+        complexity="complex",
+        outer_maximum=1000,
+        inner_maximum=500,
+        linear_acceleration="BICGSTAB",
+    )
+    gwf = flopy.mf6.ModflowGwf(
+        sim,
+        modelname="dry",
+        save_flows=True,
+        newtonoptions="NEWTON UNDER_RELAXATION",
+    )
+    flopy.mf6.ModflowGwfdis(
+        gwf,
+        nlay=2,
+        nrow=1,
+        ncol=ncol,
+        delr=100.0,
+        delc=100.0,
+        top=top,
+        botm=[mid, bot],
+    )
+    flopy.mf6.ModflowGwfic(gwf, strt=chd)
+    flopy.mf6.ModflowGwfnpf(gwf, icelltype=1, k=10.0, k33=1.0)
+    flopy.mf6.ModflowGwfsto(gwf, iconvert=1, ss=1.0e-5, sy=0.2, transient={0: True})
+    flopy.mf6.ModflowGwfdrn(
+        gwf,
+        stress_period_data={
+            p: [[(lay, 0, 0), elev, 100.0]] for p, (lay, elev) in enumerate(schedule)
+        },
+        pname="drn-1",
+    )
+    flopy.mf6.ModflowGwfchd(
+        gwf, stress_period_data=[[(1, 0, ncol - 1), chd]], pname="chd-1"
+    )
+    flopy.mf6.ModflowGwfoc(gwf, head_filerecord="dry.hds", saverecord=[("HEAD", "ALL")])
+    sim.write_simulation(silent=True)
+    success, buff = sim.run_simulation(silent=True)
+    assert success, "\n".join(buff[-20:])
+
+    heads = flopy.utils.HeadFile(str(ws / "dry.hds")).get_alldata()
+    upper = np.clip((heads[-1, 0, 0, :] - mid) / (top - mid), 0.0, 1.0)
+    assert (upper == 0.0).any(), "the upper layer is expected to go dry"
+
+    with open(ws / "pm.dat", "w") as f:
+        f.write("begin performance_measure obs\n")
+        f.write(f"  {len(schedule)} 2 2 1 4 head direct 1.0 -1.0e+30\n")
+        f.write("end performance_measure\n")
+
+    with caplog.at_level("WARNING"):
+        adj = mf6adj.Mf6Adj(
+            "pm.dat", lib_name, logging_level="WARNING", working_directory=str(ws)
+        )
+        adj.solve_forward_model(hdf5_name="fwd.hd5")
+        results = adj.solve_adjoint()
+        adj.finalize()
+
+    reported = [
+        r.message
+        for r in caplog.records
+        if "diagonal" in r.message or "residual" in r.message
+    ]
+    assert not reported, f"a model with dry cells reported {reported}"
+    assert np.nanmax(np.abs(results["obs"]["k11"].to_numpy())) < 1.0

--- a/mf6adj/pm.py
+++ b/mf6adj/pm.py
@@ -25,6 +25,12 @@ from .advanced_packages import LakeCoupling, MawCoupling, SfrCoupling
 from .packages import head_dependent, hfb, npf, recharge, well
 from .packages.head_dependent import DRAIN_CORNER_TOL, drop_corner_entries
 from .utils.utils import SolverCallback
+from .utils.utils_conditioning import (
+    LOOSE_RESIDUAL,
+    describe,
+    diagonal_report,
+    solve_residual,
+)
 from .utils.utils_fileio import _write_group_to_hdf
 from .utils.utils_logger import _LoggerUtil
 from .utils.utils_modflow import (
@@ -1021,6 +1027,14 @@ class PerfMeas:
                 + f"with solver options: {_linear_solver_kwargs}"
             )
 
+            # a row whose diagonal has fallen away carries a state that goes as
+            # one over it, which is where a sensitivity too large for the flow
+            # model to support comes from. Reading the diagonal is one pass, so
+            # it runs on every model rather than on request.
+            report = diagonal_report(amat)
+            if report is not None:
+                self.logger.logger.warning(describe(report, int(kk[0]), int(kk[1])))
+
             # solve the system of equations
             if linear_solver == "direct":
                 lamb = _linear_solver(amat, rhs, **_linear_solver_kwargs)
@@ -1093,6 +1107,20 @@ class PerfMeas:
                     self.logger.logger.error("Solver parameter breakdown")
                 elif info > 0:
                     self.logger.logger.warning("Solver convergence not achieved")
+
+            # the residual next to the right-hand side it was solved against,
+            # which says whether the solution stands rather than how large its
+            # numbers are. The direct solver reports nothing of its own, and a
+            # nearly singular matrix can return from it without complaint.
+            relative = solve_residual(amat, lamb, rhs)
+            if relative > LOOSE_RESIDUAL:
+                self.logger.logger.warning(
+                    f"the adjoint solve for stress period {int(kk[0]) + 1}, "
+                    + f"time step {int(kk[1]) + 1} left a residual "
+                    + f"{relative:.3e} times its right-hand side, so the "
+                    + "sensitivities from this step are not a solution of the "
+                    + "equations they were formed from."
+                )
 
             if self._sfr.columns:
                 # the reach depths come off first, being the outer border

--- a/mf6adj/utils/utils_conditioning.py
+++ b/mf6adj/utils/utils_conditioning.py
@@ -1,0 +1,127 @@
+"""Report an adjoint matrix that cannot carry a trustworthy sensitivity.
+
+The adjoint is solved against the matrix MODFLOW 6 assembled. A row whose
+diagonal has fallen away still solves, and the state it returns goes as one
+over that diagonal, so a measure can come back with values far larger than the
+flow model supports and nothing says why.
+
+A cell the model barely connects to is such a row, and a steady-state step is
+where it shows: a transient step carries a storage term on the diagonal, of the
+order of the specific yield over the length of the step, which holds it up. A
+cell going dry under the Newton-Raphson formulation is not such a row, measured
+rather than assumed: at four tenths of a percent saturated its diagonal sat at
+the median of the model, held there by that storage term, and its sensitivities
+fell rather than grew.
+
+The checks here are the ones affordable on a model of a few million nodes: they
+read the diagonal, which is one pass, and the residual of the solve, which is
+one matrix-vector product. A singular value decomposition tells more but cannot
+be run at that size.
+"""
+
+from typing import Optional
+
+import numpy as np
+
+# a row whose diagonal is this far below the middle of the model is reported
+SMALL_DIAGONAL = 1.0e-6
+
+# a solve is reported when its residual is this large next to its right side
+LOOSE_RESIDUAL = 1.0e-6
+
+# how many of the worst rows to name
+WORST = 5
+
+
+def diagonal_report(amat, threshold: float = SMALL_DIAGONAL) -> Optional[dict]:
+    """Return the rows of a matrix that cannot support a solution, or None.
+
+    A row with no diagonal at all is singular. A row whose diagonal is far
+    below the rest of the model is not, but the state it carries goes as one
+    over that diagonal, so it is where an implausible sensitivity comes from.
+
+    Parameters
+    ----------
+    amat : scipy.sparse.spmatrix
+        Matrix the adjoint is solved against.
+    threshold : float
+        Fraction of the median diagonal below which a row is reported.
+
+    Returns
+    -------
+    dict or None
+        ``nzero``, ``nsmall``, the median diagonal, and the worst rows with
+        their diagonals, or None when every row is sound.
+    """
+    diagonal = np.abs(np.asarray(amat.diagonal()))
+    if diagonal.size == 0:
+        return None
+
+    nonzero = diagonal[diagonal > 0.0]
+    if nonzero.size == 0:
+        return {
+            "nzero": int(diagonal.size),
+            "nsmall": 0,
+            "median": 0.0,
+            "rows": np.arange(min(WORST, diagonal.size)),
+            "diagonals": diagonal[: min(WORST, diagonal.size)],
+        }
+
+    median = float(np.median(nonzero))
+    zero = diagonal <= 0.0
+    small = (~zero) & (diagonal < threshold * median)
+    if not zero.any() and not small.any():
+        return None
+
+    flagged = np.flatnonzero(zero | small)
+    worst = flagged[np.argsort(diagonal[flagged])][:WORST]
+    return {
+        "nzero": int(zero.sum()),
+        "nsmall": int(small.sum()),
+        "median": median,
+        "rows": worst,
+        "diagonals": diagonal[worst],
+    }
+
+
+def solve_residual(amat, lamb, rhs) -> float:
+    """Return the residual of a solved system next to its right-hand side.
+
+    Parameters
+    ----------
+    amat : scipy.sparse.spmatrix
+        Matrix that was solved.
+    lamb : ndarray
+        Solution returned by the solver.
+    rhs : ndarray
+        Right-hand side it was solved against.
+
+    Returns
+    -------
+    float
+        Largest residual over the largest right-hand side, or the largest
+        residual alone where that side is zero.
+    """
+    residual = float(np.max(np.abs(amat.dot(lamb) - rhs)))
+    scale = float(np.max(np.abs(rhs)))
+    return residual / scale if scale > 0.0 else residual
+
+
+def describe(report: dict, kper: int, kstp: int) -> str:
+    """Return the message for a matrix whose rows cannot support a solution."""
+    rows = ", ".join(
+        f"{int(node)} ({value:.3e})"
+        for node, value in zip(report["rows"], report["diagonals"])
+    )
+    what = []
+    if report["nzero"]:
+        what.append(f"{report['nzero']} with no diagonal")
+    if report["nsmall"]:
+        what.append(f"{report['nsmall']} with a diagonal far below the rest")
+    return (
+        f"the adjoint matrix for stress period {kper + 1}, time step "
+        f"{kstp + 1} holds {' and '.join(what)}, against a median of "
+        f"{report['median']:.3e}. The state at such a node goes as one over "
+        f"its diagonal, so a sensitivity reported there may be far larger "
+        f"than the flow model can support. Worst nodes, zero based: {rows}."
+    )


### PR DESCRIPTION
Stacked on #142. Review that first; the diff here is against it.

A performance measure could come back with values too large for the flow model to support and nothing said why. The adjoint is solved against the matrix MODFLOW 6 assembled, and a row whose diagonal has fallen away still solves — the state it returns goes as one over that diagonal.

A cell the model barely connects to is such a row, and a step with no storage is where it shows. **A cell going dry is not**, which is measured rather than assumed: see below.

The check that existed cannot run where this happens: `singular_test` is a singular value decomposition, defaults to `False`, and is not affordable on a few million nodes.

### What runs now

Both are affordable at model scale and both report only when a threshold is crossed, so a sound model stays silent:

- **the diagonal**, read in one pass. Rows with none, or with one more than 1e6 below the median of the model, are named with their values.
- **the residual of the solve**, one matrix-vector product, given against the right-hand side rather than on its own. The existing residual logging is absolute, at `INFO`, and only for iterative solvers; the direct solver reports nothing of its own and returns from a nearly singular matrix without complaint.

### Verification

`test_conditioning.py` has 7 cases, and the two that matter sit at opposite ends. A healthy model must report **nothing**. A model with a nearly isolated cell must name it — and that model solves cleanly in MODFLOW, which is the point, since there is nothing else to notice it by. It is reported at `4.000e-10` against a median of `1.500e+02`.

Across the whole existing suite, 196 tests, nothing is reported.

### What this does not claim

A large sensitivity is not on its own evidence of ill conditioning, and none of the messages say it is. A `direct` measure summing N time steps carries N times a single step's value, which is correct.

### Drying is not the mechanism

The issue originally said a cell approaching dry under Newton-Raphson gives such a row. That is wrong. Lowering a drain stress period by stress period, against a constant head at the other end, dewaters cells where a well cannot — MODFLOW converges to four tenths of a percent saturated — and nothing collapses:

| minimum saturation | diagonal there | median diagonal |
| --- | --- | --- |
| 0.90407 | 1.0895e+03 | 9.9038e+01 |
| 0.00398 | 1.0855e+03 | 9.9053e+01 |

A transient step carries `sy A / dt` on the diagonal, which for those cells is 0.2 x 10,000 / 25 = 80, and the measured interior diagonals are 81. Drying cannot take the diagonal below that floor, and the sensitivities fall rather than grow: the largest well sensitivity over the run is 0.9986.

Emptying a cell altogether says the same thing more plainly. Moving the drain from the upper layer of a two-layer model into the lower one leaves the upper layer at a saturation of exactly zero, and MODFLOW 6 gives those cells a diagonal of exactly `1.0000e+03` against a model median of `1.1e+03` — a treatment of its own rather than a row left to fall to nothing, in the same way a constant head is given exactly `1.0`. The largest conductivity sensitivity on that model is 0.095. `test_dry_cells_are_not_reported` holds this, so the wrong mechanism is not derived again.

So the check is for a barely connected row on a step with no storage to hold it up, which is what the test builds and what the module says.

Closes #141