### PR TITLE
fix(sto): carry the storage term back with the slope of the smoothed saturation

### DIFF
--- a/autotest/test_dry_cell_storage.py
+++ b/autotest/test_dry_cell_storage.py
@@ -18,7 +18,9 @@ Cases:
   - test_slope_at_the_ends       : an empty or a full cell passes nothing back.
   - test_slope_inside_rounding   : a cell just above its bottom passes back
                                    almost nothing, not the whole term.
-  - test_confined_cell_has_none  : a cell that never converts is unaffected.
+  - test_without_newton          : a model that does not use the Newton-Raphson
+                                   formulation has no rounding, and the slope
+                                   is the plain one it was before.
 """
 
 import pathlib as pl
@@ -33,13 +35,17 @@ except ImportError:
     sys.path.insert(0, str(pl.Path("../").resolve()))
     import mf6adj
 
-from mf6adj.packages.storage import SATOMEGA, smoothed_saturation_slope
+from mf6adj.packages.storage import smoothed_saturation_slope
+
+# MODFLOW sets this only under the Newton-Raphson formulation, and leaves it
+# at zero otherwise
+NEWTON_OMEGA = 1.0e-6
 
 TOP, BOT = 10.0, 0.0
 THICK = TOP - BOT
 
 
-def modflow_slope(head, top=TOP, bot=BOT, eps=SATOMEGA):
+def modflow_slope(head, top=TOP, bot=BOT, eps=NEWTON_OMEGA):
     """sQuadraticSaturationDerivative of SmoothingFunctions.f90, over the thickness."""
     b = top - bot
     if head < bot:
@@ -70,7 +76,7 @@ def modflow_slope(head, top=TOP, bot=BOT, eps=SATOMEGA):
         2.0,
         5.0,
         9.0,
-        THICK * (1.0 - SATOMEGA / 2.0),
+        THICK * (1.0 - NEWTON_OMEGA / 2.0),
         10.0,
         15.0,
     ],
@@ -78,7 +84,9 @@ def modflow_slope(head, top=TOP, bot=BOT, eps=SATOMEGA):
 def test_slope_matches_modflow(head):
     """The slope is the one MODFLOW forms, at every part of the cell."""
     got = float(
-        smoothed_saturation_slope(np.array([head]), np.array([TOP]), np.array([BOT]))[0]
+        smoothed_saturation_slope(
+            np.array([head]), np.array([TOP]), np.array([BOT]), NEWTON_OMEGA
+        )[0]
     )
     assert np.isclose(got, modflow_slope(head), rtol=1e-12, atol=1e-14)
 
@@ -98,16 +106,24 @@ def test_slope_inside_rounding():
     negligible, and the term it was given was the whole one.
     """
     head = np.array([BOT + 3.3e-8])
-    slope = float(smoothed_saturation_slope(head, np.array([TOP]), np.array([BOT]))[0])
+    slope = float(
+        smoothed_saturation_slope(head, np.array([TOP]), np.array([BOT]), NEWTON_OMEGA)[
+            0
+        ]
+    )
     # the fraction of the cell the head stands in, over the rounding width
-    assert np.isclose(slope, (3.3e-8 / THICK) / SATOMEGA / (1.0 - SATOMEGA))
+    assert np.isclose(slope, (3.3e-8 / THICK) / NEWTON_OMEGA / (1.0 - NEWTON_OMEGA))
     assert slope < 1.0e-2, "a cell holding no water still carries the whole term"
 
     # and the slope rises to one only once the head is clear of the rounding
-    clear = np.array([BOT + 2.0 * SATOMEGA * THICK])
+    clear = np.array([BOT + 2.0 * NEWTON_OMEGA * THICK])
     assert np.isclose(
-        float(smoothed_saturation_slope(clear, np.array([TOP]), np.array([BOT]))[0]),
-        1.0 / (1.0 - SATOMEGA),
+        float(
+            smoothed_saturation_slope(
+                clear, np.array([TOP]), np.array([BOT]), NEWTON_OMEGA
+            )[0]
+        ),
+        1.0 / (1.0 - NEWTON_OMEGA),
     )
 
 
@@ -115,7 +131,22 @@ def test_slope_is_bounded():
     """The slope never exceeds the linear one, wherever the head stands."""
     heads = np.linspace(BOT - 1.0, TOP + 1.0, 20001)
     slope = smoothed_saturation_slope(
-        heads, np.full(heads.size, TOP), np.full(heads.size, BOT)
+        heads, np.full(heads.size, TOP), np.full(heads.size, BOT), NEWTON_OMEGA
     )
     assert slope.min() >= 0.0
-    assert slope.max() <= 1.0 / (1.0 - SATOMEGA) + 1.0e-12
+    assert slope.max() <= 1.0 / (1.0 - NEWTON_OMEGA) + 1.0e-12
+
+
+def test_without_newton():
+    """No rounding without Newton-Raphson, so the slope is the plain one.
+
+    MODFLOW leaves ``satomega`` at zero outside the Newton-Raphson formulation
+    (gwf-sto.f90), where the saturation follows the head over the whole cell.
+    The term is then what it was before this was changed, so a model solved
+    that way is unaffected.
+    """
+    heads = np.array([BOT - 1.0, BOT, BOT + 3.3e-8, 5.0, TOP, TOP + 1.0])
+    slope = smoothed_saturation_slope(
+        heads, np.full(heads.size, TOP), np.full(heads.size, BOT), 0.0
+    )
+    assert np.array_equal(slope, np.array([0.0, 0.0, 1.0, 1.0, 0.0, 0.0]))

--- a/autotest/test_dry_cell_storage.py
+++ b/autotest/test_dry_cell_storage.py
@@ -1,0 +1,121 @@
+"""
+Tests the storage term that carries the adjoint state back through a dry cell.
+
+The previous head enters the specific-yield term through the saturation it
+sets, so the derivative carries the slope of that saturation. MODFLOW 6 rounds
+the saturation at both ends of a cell, and in that rounding the slope falls
+away to nothing. A cell that has emptied does not hold a saturation of exactly
+zero, it holds whatever the rounding gives it, so a term that asks only whether
+the saturation is above zero hands back the whole coupling for a cell holding
+no water.
+
+Where that coupling is larger than the diagonal of the matrix, the adjoint
+state is multiplied by the ratio once per time step, and the sensitivities grow
+without bound backward in time.
+
+Cases:
+  - test_slope_matches_modflow   : the slope is MODFLOW's, over the thickness.
+  - test_slope_at_the_ends       : an empty or a full cell passes nothing back.
+  - test_slope_inside_rounding   : a cell just above its bottom passes back
+                                   almost nothing, not the whole term.
+  - test_confined_cell_has_none  : a cell that never converts is unaffected.
+"""
+
+import pathlib as pl
+import sys
+
+import numpy as np
+import pytest
+
+try:
+    import mf6adj
+except ImportError:
+    sys.path.insert(0, str(pl.Path("../").resolve()))
+    import mf6adj
+
+from mf6adj.packages.storage import SATOMEGA, smoothed_saturation_slope
+
+TOP, BOT = 10.0, 0.0
+THICK = TOP - BOT
+
+
+def modflow_slope(head, top=TOP, bot=BOT, eps=SATOMEGA):
+    """sQuadraticSaturationDerivative of SmoothingFunctions.f90, over the thickness."""
+    b = top - bot
+    if head < bot:
+        br = 0.0
+    elif head > top:
+        br = 1.0
+    else:
+        br = (head - bot) / b
+    av = 1.0 / (1.0 - eps)
+    if br < eps:
+        return av * br / eps
+    if br < 1.0 - eps:
+        return av
+    if br < 1.0:
+        return av * (1.0 - br) / eps
+    return 0.0
+
+
+@pytest.mark.parametrize(
+    "head",
+    [
+        -5.0,
+        0.0,
+        1.0e-9,
+        1.0e-6,
+        1.0e-4,
+        0.5,
+        2.0,
+        5.0,
+        9.0,
+        THICK * (1.0 - SATOMEGA / 2.0),
+        10.0,
+        15.0,
+    ],
+)
+def test_slope_matches_modflow(head):
+    """The slope is the one MODFLOW forms, at every part of the cell."""
+    got = float(
+        smoothed_saturation_slope(np.array([head]), np.array([TOP]), np.array([BOT]))[0]
+    )
+    assert np.isclose(got, modflow_slope(head), rtol=1e-12, atol=1e-14)
+
+
+def test_slope_at_the_ends():
+    """A cell that is empty or full passes nothing back."""
+    heads = np.array([BOT - 1.0, BOT, TOP, TOP + 1.0])
+    slope = smoothed_saturation_slope(heads, np.full(4, TOP), np.full(4, BOT))
+    assert np.allclose(slope, 0.0)
+
+
+def test_slope_inside_rounding():
+    """A cell just above its bottom passes back almost nothing.
+
+    This is the case that grew without bound: a head a hundred-millionth of a
+    metre above the bottom of the cell leaves a saturation that is positive but
+    negligible, and the term it was given was the whole one.
+    """
+    head = np.array([BOT + 3.3e-8])
+    slope = float(smoothed_saturation_slope(head, np.array([TOP]), np.array([BOT]))[0])
+    # the fraction of the cell the head stands in, over the rounding width
+    assert np.isclose(slope, (3.3e-8 / THICK) / SATOMEGA / (1.0 - SATOMEGA))
+    assert slope < 1.0e-2, "a cell holding no water still carries the whole term"
+
+    # and the slope rises to one only once the head is clear of the rounding
+    clear = np.array([BOT + 2.0 * SATOMEGA * THICK])
+    assert np.isclose(
+        float(smoothed_saturation_slope(clear, np.array([TOP]), np.array([BOT]))[0]),
+        1.0 / (1.0 - SATOMEGA),
+    )
+
+
+def test_slope_is_bounded():
+    """The slope never exceeds the linear one, wherever the head stands."""
+    heads = np.linspace(BOT - 1.0, TOP + 1.0, 20001)
+    slope = smoothed_saturation_slope(
+        heads, np.full(heads.size, TOP), np.full(heads.size, BOT)
+    )
+    assert slope.min() >= 0.0
+    assert slope.max() <= 1.0 / (1.0 - SATOMEGA) + 1.0e-12

--- a/autotest/test_sto.py
+++ b/autotest/test_sto.py
@@ -159,8 +159,12 @@ def test_confined_only_drops_partial_cells(function_tmpdir):
     dt = 400.0 / NSTP
     partial = sat < 1.0
     assert partial.any(), "the model has to leave cells partly drained"
-    # below full saturation only the specific-yield term survives
-    expected = -area * sy / dt
+    # Below full saturation only the specific-yield term survives. It carries
+    # the slope of the smoothed saturation, which MODFLOW 6 puts at
+    # 1 / (1 - satomega) rather than at one where the saturation follows the
+    # head, so the term is larger than the plain capacity by that much.
+    satomega = 1.0e-6
+    expected = -area * sy / dt / (1.0 - satomega)
     assert np.allclose(drhsdh[partial], expected, rtol=1e-8), (
         "specific storage is still applied where MODFLOW 6 drops it"
     )

--- a/mf6adj/adj.py
+++ b/mf6adj/adj.py
@@ -831,7 +831,12 @@ class Mf6Adj:
                     )
                     data_dict["dresdsy_h"] = dresdsy_h
                     drhsdh = storage.drhsdh(
-                        self._gwf, self._gwf_name, self.logger.logger, dt1, sat_old
+                        self._gwf,
+                        self._gwf_name,
+                        self.logger.logger,
+                        dt1,
+                        sat_old,
+                        head,
                     )
                     data_dict["drhsdh"] = drhsdh
                 else:

--- a/mf6adj/packages/storage.py
+++ b/mf6adj/packages/storage.py
@@ -9,6 +9,9 @@ approximating it.
 
 import numpy as np
 
+# default SATOMEGA of the MODFLOW 6 storage package
+SATOMEGA = 1.0e-6
+
 from ..utils.utils_modflow import get_ptr_from_gwf
 
 
@@ -146,12 +149,61 @@ def dresdsy_h(
     return result
 
 
+def smoothed_saturation_slope(head, top, bot, satomega: float = SATOMEGA):
+    """Return the thickness times the slope of the smoothed saturation.
+
+    MODFLOW 6 does not let the saturation follow the head linearly all the way
+    to the ends of a cell. It rounds both corners over a fraction ``satomega``
+    of the thickness, so the slope falls away to nothing as the cell empties or
+    fills. This is sQuadraticSaturationDerivative of SmoothingFunctions.f90,
+    taken over the thickness, so it is one where the saturation follows the
+    head and zero at either end.
+
+    It is formed from the head rather than from the saturation, as MODFLOW
+    forms it: the two do not agree inside the rounding, where the saturation is
+    quadratic in the head.
+
+    Parameters
+    ----------
+    head : ndarray
+        Head the saturation is taken at.
+    top, bot : ndarray
+        Top and bottom of each cell.
+    satomega : float
+        Fraction of the cell the rounding covers.
+
+    Returns
+    -------
+    ndarray
+        Slope over the linear slope, between zero and one.
+    """
+    thickness = np.asarray(top - bot, dtype=float)
+    over = np.divide(
+        np.asarray(head, dtype=float) - bot,
+        thickness,
+        out=np.zeros_like(thickness),
+        where=thickness > 0.0,
+    )
+    fraction = np.clip(over, 0.0, 1.0)
+    scale = 1.0 / (1.0 - satomega) if satomega < 1.0 else 1.0
+    return np.where(
+        fraction < satomega,
+        scale * fraction / satomega,
+        np.where(
+            fraction < 1.0 - satomega,
+            scale,
+            np.where(fraction < 1.0, scale * (1.0 - fraction) / satomega, 0.0),
+        ),
+    )
+
+
 def drhsdh(
     gwf,
     gwf_name: str,
     logger,
     dt: float,
     sat_old: np.ndarray,
+    head: np.ndarray,
 ) -> np.ndarray:
     """Return the previous-head derivative of the storage right-hand side.
 
@@ -166,6 +218,9 @@ def drhsdh(
         Length of the current solution step in model time.
     sat_old : ndarray
         Saturation from the previous solution step.
+    head : ndarray
+        Head the saturation is taken at, which the slope of the smoothed
+        saturation is formed from.
 
     Returns
     -------
@@ -208,7 +263,15 @@ def drhsdh(
 
     # specific yield, which enters only through the saturation and so
     # vanishes once the cell is full or dry
+    # The previous head enters the specific-yield term through the saturation
+    # it sets, so the derivative carries the slope of that saturation. MODFLOW
+    # rounds the saturation at both ends of the cell and the slope falls away
+    # there, so a cell that has emptied passes almost nothing back rather than
+    # the whole term: at a saturation of 1e-19 the two differ by a million, and
+    # the adjoint state grows by that ratio once per time step.
     sy_term = area * sy / dt
-    sy_scale = np.where((sat_old_mod > 0.0) & (sat_old_mod < 1.0), 1.0, 0.0)
+    # a cell that never converts releases nothing through specific yield,
+    # whatever its head
+    sy_scale = np.where(iconvert == 0, 0.0, smoothed_saturation_slope(head, top, bot))
 
     return -1.0 * (ss_term * ss_scale + sy_term * sy_scale)

--- a/mf6adj/packages/storage.py
+++ b/mf6adj/packages/storage.py
@@ -9,8 +9,10 @@ approximating it.
 
 import numpy as np
 
-# default SATOMEGA of the MODFLOW 6 storage package
-SATOMEGA = 1.0e-6
+# the storage package's SATOMEGA where it cannot be read. MODFLOW 6 leaves it
+# at zero and sets it only under the Newton-Raphson formulation, so with no
+# rounding the saturation follows the head over the whole cell.
+SATOMEGA = 0.0
 
 from ..utils.utils_modflow import get_ptr_from_gwf
 
@@ -170,7 +172,8 @@ def smoothed_saturation_slope(head, top, bot, satomega: float = SATOMEGA):
     top, bot : ndarray
         Top and bottom of each cell.
     satomega : float
-        Fraction of the cell the rounding covers.
+        Fraction of the cell the rounding covers. MODFLOW leaves this at zero
+        outside the Newton-Raphson formulation.
 
     Returns
     -------
@@ -185,6 +188,11 @@ def smoothed_saturation_slope(head, top, bot, satomega: float = SATOMEGA):
         where=thickness > 0.0,
     )
     fraction = np.clip(over, 0.0, 1.0)
+    # with no rounding the saturation follows the head over the whole cell, so
+    # the slope is one inside it and nothing at either end
+    if satomega <= 0.0:
+        return np.where((fraction > 0.0) & (fraction < 1.0), 1.0, 0.0)
+
     scale = 1.0 / (1.0 - satomega) if satomega < 1.0 else 1.0
     return np.where(
         fraction < satomega,
@@ -272,6 +280,13 @@ def drhsdh(
     sy_term = area * sy / dt
     # a cell that never converts releases nothing through specific yield,
     # whatever its head
-    sy_scale = np.where(iconvert == 0, 0.0, smoothed_saturation_slope(head, top, bot))
+    # MODFLOW rounds the saturation only under Newton-Raphson, so the width of
+    # that rounding is read from the package rather than assumed
+    satomega = float(
+        np.asarray(get_ptr_from_gwf(gwf_name, "STO", "SATOMEGA", gwf)).ravel()[0]
+    )
+    sy_scale = np.where(
+        iconvert == 0, 0.0, smoothed_saturation_slope(head, top, bot, satomega)
+    )
 
     return -1.0 * (ss_term * ss_scale + sy_term * sy_scale)


### PR DESCRIPTION
The adjoint state grew without bound backward in time on a model holding a cell that had gone dry. On a CONUS subdomain over four stress periods the composite well sensitivity came back as **3.0e+25**, where a streamflow capture fraction cannot exceed 1.

### Cause

The previous head enters the specific-yield term through the saturation it sets, so the derivative carries the slope of that saturation. MODFLOW rounds the saturation at both ends of a cell and the slope falls away there, but `drhsdh` asked only whether the saturation was above zero:

```python
sy_scale = np.where((sat_old_mod > 0.0) & (sat_old_mod < 1.0), 1.0, 0.0)
```

A cell that has emptied does not hold a saturation of exactly zero. At the cell this was found on the head stood **3.3e-08 m above the bottom of a cell 20 m thick**, so the saturation was 3e-19, and `3e-19 > 0.0` is true. It was handed the whole coupling, 16.2, against a matrix diagonal of 3e-04, and the backward step multiplies the state by that ratio once per time step.

### Fix

Form the slope from the head, as `sQuadraticSaturationDerivative` of `SmoothingFunctions.f90` forms it. The width of the rounding is **read from the storage package**: MODFLOW leaves `SATOMEGA` at zero and sets it only under the Newton-Raphson formulation (`gwf-sto.f90:829`), so a model solved without Newton has no rounding and is unchanged. `test_without_newton` holds that.

### Measured, re-solving the model with this change

| step | before | after |
| --- | --- | --- |
| kper 0, kstp 0 | 2.8983e+25 | 0.0969 |
| kper 2, kstp 2 | 2.7874e+17 | 0.1371 |
| kper 3, kstp 2 | 2.7617e+07 | 0.6308 |
| kper 3, kstp 4 (the measure) | 1.0000 | 1.0000 |
| **composite** | **3.0214e+25** | **1.5548** |

The per-step results now fall away backward in time rather than growing. Twenty-five orders of magnitude.

### What this does not fix

A capture fraction cannot exceed 1, and the composite is 1.55. The largest coupling over the diagonal is now 0.977 at nine of the ten steps, and 6.57 at one cell of one step, which is the step that stands out above.

That cell is not a storage defect. Its coupling there is 2e-03, which is correct, against a matrix diagonal of 3.04e-04 where the model's median is 144. MODFLOW branches the specific-yield matrix term on the **new** saturation while the derivative involves the **old** one, so at a cell sitting on the floor of the rounding the two disagree and the row carries almost nothing. A coupling larger than the diagonal amplifies however right the coupling is. That is the near-singular row of #141.

Only the ten-step model was re-solved. The six-step one reached 1.6e+10 before and is expected to behave the same, which has not been measured.

Closes #147