### PR TITLE
fix(pm): hold the adjoint state at zero where a cell holds no water

### DIFF
--- a/autotest/test_dry_cell_state.py
+++ b/autotest/test_dry_cell_state.py
@@ -12,11 +12,25 @@ Cases:
                                precision counts as dry, and one above it does not.
   - test_none_when_wet       : a model with no dry cell selects nothing.
   - test_shape_is_flat       : a grid-shaped saturation gives flat indices.
+  - test_state_is_held_at_zero : the solve acts on the selection, on a forward
+                               file with one cell put into the state that grew.
+
+No model this size reaches that state on its own. MODFLOW gives a cell that
+empties altogether a diagonal of its own, and the state there is already
+nothing, so a test on such a model holds whether the solve acts or not. The
+condition wants a cell the smoothing leaves at a saturation of 1e-19 with a
+diagonal that has fallen below the term carrying the state back, which was
+found on a model of a few million cells. The forward file of a small model is
+edited into it instead: the adjoint is solved from that file and never from a
+running model, so nothing else is needed.
 """
 
 import pathlib as pl
+import shutil
 import sys
 
+import flopy
+import h5py
 import numpy as np
 
 try:
@@ -45,3 +59,102 @@ def test_shape_is_flat():
     sat = np.ones((1, 3, 4))
     sat[0, 2, 1] = 0.0
     assert np.array_equal(dry_cells(sat), np.array([9]))
+
+
+def _build(ws, nstp=4):
+    """A strip aquifer with a stream at one end, a well, and a constant head."""
+    ws = pl.Path(ws)
+    if ws.exists():
+        shutil.rmtree(ws)
+    ws.mkdir(parents=True)
+    mf6_bin, _ = mf6adj.get_conda_mf6_paths()
+
+    sim = flopy.mf6.MFSimulation(sim_name="dry", sim_ws=str(ws), exe_name=mf6_bin)
+    flopy.mf6.ModflowTdis(sim, nper=1, perioddata=[(100.0, nstp, 1.0)])
+    flopy.mf6.ModflowIms(sim, complexity="simple")
+    gwf = flopy.mf6.ModflowGwf(sim, modelname="dry", save_flows=True)
+    flopy.mf6.ModflowGwfdis(
+        gwf, nlay=1, nrow=1, ncol=10, delr=100.0, delc=100.0, top=10.0, botm=0.0
+    )
+    flopy.mf6.ModflowGwfic(gwf, strt=10.0)
+    flopy.mf6.ModflowGwfnpf(gwf, icelltype=0, k=10.0)
+    flopy.mf6.ModflowGwfsto(gwf, iconvert=0, ss=1.0e-5, sy=0.2, transient={0: True})
+    flopy.mf6.ModflowGwfdrn(
+        gwf, stress_period_data=[[(0, 0, 0), 5.0, 1000.0]], pname="drn-1"
+    )
+    flopy.mf6.ModflowGwfchd(gwf, stress_period_data=[[(0, 0, 9), 10.0]], pname="chd-1")
+    flopy.mf6.ModflowGwfwel(gwf, stress_period_data=[[(0, 0, 4), -20.0]], pname="wel-1")
+    flopy.mf6.ModflowGwfoc(gwf, head_filerecord="dry.hds", saverecord=[("HEAD", "ALL")])
+    sim.write_simulation(silent=True)
+    success, buff = sim.run_simulation(silent=True)
+    assert success, "\n".join(buff[-20:])
+
+    with open(ws / "pm.dat", "w") as f:
+        f.write("begin performance_measure obs\n")
+        f.write(f"  1 {nstp} 1 1 1 drn-1 direct 1.0 -1.0e+30\n")
+        f.write("end performance_measure\n")
+    return ws
+
+
+def _empty_one_cell(src, dst, node, sat=1.0e-19, diagonal=3.0e-4, carry=2.0e-3):
+    """Put one cell of a forward file into the state a dry cell reaches."""
+    shutil.copy(src, dst)
+    with h5py.File(dst, "r+") as f:
+        ia = np.asarray(f["gwf_info"]["sln_ia"][:]).astype(int)
+        ja = np.asarray(f["gwf_info"]["sln_ja"][:]).astype(int)
+        if ia.min() == 1:
+            ia, ja = ia - 1, ja - 1
+
+        iconvert = f["gwf_info"]["iconvert"][:]
+        iconvert.reshape(-1)[node] = 1
+        f["gwf_info"]["iconvert"][...] = iconvert
+
+        for key in [k for k in f if k.startswith("solution_kper")]:
+            group = f[key]
+            for name in ("sat", "sat_old"):
+                values = np.asarray(group[name][:])
+                values.reshape(-1)[node] = sat
+                group[name][...] = values
+
+            # the diagonal falls away while the term carrying the state back
+            # does not, which multiplies the state once per time step
+            amat = np.asarray(group["amat"][:])
+            for position in range(ia[node], ia[node + 1]):
+                amat[position] = -diagonal if ja[position] == node else 0.0
+            group["amat"][...] = amat
+
+            drhsdh = np.asarray(group["drhsdh"][:])
+            drhsdh.reshape(-1)[node] = -carry
+            group["drhsdh"][...] = drhsdh
+
+
+def test_state_is_held_at_zero(function_tmpdir):
+    """The solve holds the state at zero where the forward file says dry.
+
+    Left to grow, the state at that cell reaches 1.6e+07 over four time steps,
+    multiplied by the ratio of the coupling to the diagonal once per step.
+    """
+    node = 6
+    ws = _build(function_tmpdir / "run")
+    _, lib_name = mf6adj.get_conda_mf6_paths()
+
+    adj = mf6adj.Mf6Adj(
+        "pm.dat", lib_name, logging_level="ERROR", working_directory=str(ws)
+    )
+    adj.solve_forward_model(hdf5_name="fwd.hd5")
+    _empty_one_cell(ws / "fwd.hd5", ws / "dried.hd5", node)
+    adj._performance_measures[0].solve_adjoint(
+        ws / "dried.hd5", hdf5_adjoint_solution_fname=str(ws / "dried_adj.hd5")
+    )
+    adj.finalize()
+
+    with h5py.File(ws / "dried_adj.hd5", "r") as out:
+        steps = sorted(k for k in out if k.startswith("solution_kper"))
+        assert len(steps) > 1, "the state has to cross more than one step to grow"
+        for key in steps:
+            state = np.asarray(out[key]["lambda"][:]).ravel()
+            assert state[node] == 0.0, f"{key} carries {state[node]:.4e} at a dry cell"
+            assert np.abs(state).max() <= 1.0 + 1.0e-6, (
+                f"{key} reports {np.abs(state).max():.4e}, above what a "
+                "capture fraction can reach"
+            )

--- a/autotest/test_dry_cell_state.py
+++ b/autotest/test_dry_cell_state.py
@@ -1,0 +1,47 @@
+"""
+Tests that a cell holding no water carries no adjoint state.
+
+Nothing flows through a dry cell, so no sensitivity reaches through it. Its row
+stays in the matrix, and under the Newton-Raphson formulation it still holds a
+coefficient for every neighbour, whose residuals follow its head. What it loses
+is its diagonal, which the storage term carrying the state back can exceed, and
+the state is then multiplied once per time step.
+
+Cases:
+  - test_dry_below_precision : a saturation below the square root of machine
+                               precision counts as dry, and one above it does not.
+  - test_none_when_wet       : a model with no dry cell selects nothing.
+  - test_shape_is_flat       : a grid-shaped saturation gives flat indices.
+"""
+
+import pathlib as pl
+import sys
+
+import numpy as np
+
+try:
+    import mf6adj
+except ImportError:
+    sys.path.insert(0, str(pl.Path("../").resolve()))
+    import mf6adj
+
+from mf6adj.utils.utils_conditioning import DPRECSQRT, dry_cells
+
+
+def test_dry_below_precision():
+    """A saturation below the square root of machine precision counts as dry."""
+    assert np.isclose(DPRECSQRT, np.sqrt(np.finfo(float).eps))
+    sat = np.array([1.0, 0.5, DPRECSQRT * 2.0, DPRECSQRT / 2.0, 3.19e-19, 0.0])
+    assert np.array_equal(dry_cells(sat), np.array([3, 4, 5]))
+
+
+def test_none_when_wet():
+    """A model with no dry cell selects nothing."""
+    assert dry_cells(np.array([1.0, 0.9, 0.5, 1.0e-3])).size == 0
+
+
+def test_shape_is_flat():
+    """A grid-shaped saturation gives indices into the flat node numbering."""
+    sat = np.ones((1, 3, 4))
+    sat[0, 2, 1] = 0.0
+    assert np.array_equal(dry_cells(sat), np.array([9]))

--- a/mf6adj/pm.py
+++ b/mf6adj/pm.py
@@ -29,6 +29,7 @@ from .utils.utils_conditioning import (
     LOOSE_RESIDUAL,
     describe,
     diagonal_report,
+    dry_cells,
     solve_residual,
 )
 from .utils.utils_fileio import _write_group_to_hdf
@@ -1186,6 +1187,15 @@ class PerfMeas:
                     chd_nodelist.extend(nodelist)
             chd_nodelist = np.array(chd_nodelist, dtype=int)
             lamb[chd_nodelist] = 0.0
+
+            # zero out the adj state for dry cells, as for chd. Nothing flows
+            # through a cell holding no water, and its diagonal can fall below
+            # the storage term carrying the state back, which multiplies it
+            parched = dry_cells(hdf[sol_key]["sat"][:])
+            parched = parched[parched < lamb.shape[0]]
+            if parched.size:
+                self.logger.logger.debug(f"holding {parched.size} dry cells at zero")
+                lamb[parched] = 0.0
 
             start = datetime.now()
             self.logger.logger.debug("Formulating lam_dresdk_h")

--- a/mf6adj/utils/utils_conditioning.py
+++ b/mf6adj/utils/utils_conditioning.py
@@ -125,3 +125,25 @@ def describe(report: dict, kper: int, kstp: int) -> str:
         f"its diagonal, so a sensitivity reported there may be far larger "
         f"than the flow model can support. Worst nodes, zero based: {rows}."
     )
+
+
+# square root of machine precision, MODFLOW 6's DPRECSQRT
+DPRECSQRT = float(np.sqrt(np.finfo(float).eps))
+
+
+def dry_cells(saturation, tol: float = DPRECSQRT) -> np.ndarray:
+    """Return the cells holding no water.
+
+    Parameters
+    ----------
+    saturation : ndarray
+        Cell saturation.
+    tol : float
+        Saturation below which a cell holds no water.
+
+    Returns
+    -------
+    ndarray
+        Indices of the cells holding none.
+    """
+    return np.flatnonzero(np.asarray(saturation).ravel() < tol)


### PR DESCRIPTION
A cell that has gone dry still carried an adjoint state, and on a CONUS subdomain that one cell set the answer. The composite well sensitivity came back as **1.5548**, where a streamflow capture fraction cannot exceed 1 and the largest value anywhere else in the model was exactly **1.0000**.

### Cause

Nothing flows through a cell holding no water, so no sensitivity reaches through it. Its row stays in the matrix, and under the Newton-Raphson formulation it still holds a coefficient for every neighbour, whose residuals follow its head. What it loses is its diagonal.

At the cell this was found on, the diagonal fell to `3.04e-04` while the storage term carrying the state back was `2.0e-03`, so the state was multiplied by 6.57 in one step. The head there was between 1e-10 and 3e-08 m above the bottom of a cell 20 m thick, for the whole run.

### Fix

Hold the state at zero, as `pm.py` already does for a constant head, for the same reason.

A cell counts as holding no water below the square root of machine precision, MODFLOW 6's `DPRECSQRT` of `Constants.f90`. Precision itself is too strict: these are ratios of numbers that are already small, and `DPREC` leaves the cell counted as wet at every step of the model above.

### Measured, re-solving the model

| step | before | after |
| --- | --- | --- |
| kper 3, kstp 2 | 0.6308 | 0.2405 |
| kper 3, kstp 3 | 0.3447 | 0.3447 |
| kper 3, kstp 4 (the measure) | 1.0000 | 1.0000 |
| **composite** | **1.5548** | **1.0000** |

The per-step results now fall away backward in time from the measure without the step that stood out: 1.0000, 0.3447, 0.2405, 0.1906, 0.1608, 0.1371, 0.1239, 0.1124, 0.1048, 0.0969.

Four cells of 2,375,722 are held.

### Tests

`autotest/test_dry_cell_state.py`. Three cases cover the selection, and one covers the solve acting on it.

No model small enough to test with reaches the state. MODFLOW gives a cell that empties altogether a diagonal of its own, and the state there is already nothing, so a test on such a model holds whether the solve acts or not. The adjoint is solved from a forward file and never from a running model, so the file of a ten cell model is edited into the state instead: one cell is given a saturation of 1e-19, a diagonal of 3e-04, and a coupling of 2e-03.

Without this change that test fails with

```
solution_kper:00000_kstp:00000 carries -1.6158e+07 at a dry cell
```

which is the state growing 6.67 times a step over four steps, against the 6.57 of the model this was found on. It also holds every step to what a capture fraction can reach, so it covers the state growing anywhere and not only at that cell.

An earlier test ran a model whose upper layer empties and asserted the same thing. It passed with the fix taken out, and is gone.

### This is a judgement, not only a defect

Holding the state at zero gives up a path that a cell wetting again later could carry. It is decided for each time step, so a cell holding water at that step keeps its state, and the cells here are dry throughout. Whether that holds for a model where cells wet and dry through the run has not been tested.

### A correction to the issue

#149 describes the cell as disconnected. That is true of the matrix MODFLOW assembles and false of the one the adjoint solves. In `A` the row is empty; in `A^T` it carries off-diagonal weight `2.91e-04` against a diagonal of `3.04e-04`, because the Newton matrix is asymmetric and the neighbours' residuals follow the dry cell's head. A first attempt tested connectivity and selected nothing, which the re-run caught: the composite did not move.

Closes #149