### PR TITLE
perf(pm): fall back on the point Jacobi preconditioner, not the block

### DIFF
--- a/autotest/test_preconditioner.py
+++ b/autotest/test_preconditioner.py
@@ -15,8 +15,11 @@ Cases:
                                    to be the faster of the two.
   - test_the_fallback_solves     : the solve that falls back still reaches an
                                    answer.
+  - test_a_block_that_is_too_large_is_reported : a block above the size one
+                                   was measured to solve at is reported.
 """
 
+import logging
 import pathlib as pl
 import shutil
 import sys
@@ -31,7 +34,7 @@ except ImportError:
     sys.path.insert(0, str(pl.Path("../").resolve()))
     import mf6adj
 
-from mf6adj.pm import BLOCK_SIZE, PerfMeas
+from mf6adj.pm import BLOCK_SIZE, BLOCK_SIZE_LIMIT, PerfMeas
 
 mf6_bin, lib_name = mf6adj.get_conda_mf6_paths()
 
@@ -154,3 +157,34 @@ def test_the_fallback_solves(function_tmpdir, monkeypatch):
         state = np.asarray(f[keys[-1]]["lambda"][:])
     assert np.isfinite(state).all(), "the fallback solve returned no number"
     assert np.abs(state).max() > 0.0, "the fallback solve returned nothing"
+
+
+def test_a_block_that_is_too_large_is_reported(caplog):
+    """A block above the size one was measured to solve at is reported.
+
+    A block growing toward the whole matrix carries the failure of the whole
+    factorization into the preconditioner.
+    """
+
+    class Shim:
+        logger = type("L", (), {"logger": logging.getLogger("pre")})()
+
+    amat = _matrix(BLOCK_SIZE_LIMIT + 100)
+
+    with caplog.at_level("WARNING"):
+        PerfMeas._setup_block_jacobi_preconditioner(
+            Shim(), amat, block_size=BLOCK_SIZE_LIMIT + 100
+        )
+    assert [r for r in caplog.records if "rows to a block" in r.message], (
+        "a block above the size measured was not reported"
+    )
+
+    # and the size that is the default is not reported
+    caplog.clear()
+    with caplog.at_level("WARNING"):
+        PerfMeas._setup_block_jacobi_preconditioner(
+            Shim(), _matrix(BLOCK_SIZE + 100), block_size=BLOCK_SIZE
+        )
+    assert not [r for r in caplog.records if "rows to a block" in r.message], (
+        "the block size the solve uses was reported"
+    )

--- a/autotest/test_preconditioner.py
+++ b/autotest/test_preconditioner.py
@@ -1,0 +1,156 @@
+"""
+Tests the preconditioner the adjoint solve is carried out with.
+
+The adjoint is solved against the transpose of the matrix MODFLOW 6
+assembled, preconditioned by an incomplete factorization of it. A matrix that
+factorization cannot be formed for falls back on a Jacobi preconditioner
+instead, which is where the choice between the point and the block form is
+made.
+
+Cases:
+  - test_a_block_holds_the_whole_matrix : a matrix with fewer rows than a
+                                   block is one block.
+  - test_the_fallback_is_point   : a factorization that cannot be formed falls
+                                   back on the point form, which is measured
+                                   to be the faster of the two.
+  - test_the_fallback_solves     : the solve that falls back still reaches an
+                                   answer.
+"""
+
+import pathlib as pl
+import shutil
+import sys
+
+import flopy
+import numpy as np
+import scipy.sparse as sps
+
+try:
+    import mf6adj
+except ImportError:
+    sys.path.insert(0, str(pl.Path("../").resolve()))
+    import mf6adj
+
+from mf6adj.pm import BLOCK_SIZE, PerfMeas
+
+mf6_bin, lib_name = mf6adj.get_conda_mf6_paths()
+
+
+def _matrix(n):
+    """A matrix with a diagonal and a little off-diagonal weight."""
+    mat = sps.lil_matrix((n, n))
+    for i in range(n):
+        mat[i, i] = 10.0
+        if i + 1 < n:
+            mat[i, i + 1] = -1.0
+            mat[i + 1, i] = -1.0
+    return mat.tocsr()
+
+
+def _forward_file(ws):
+    """Return the forward file of a small transient model."""
+    ws = pl.Path(ws)
+    if ws.exists():
+        shutil.rmtree(ws)
+    ws.mkdir(parents=True)
+
+    sim = flopy.mf6.MFSimulation(sim_name="pre", sim_ws=str(ws), exe_name=mf6_bin)
+    flopy.mf6.ModflowTdis(sim, nper=1, perioddata=[(100.0, 2, 1.0)])
+    flopy.mf6.ModflowIms(sim, complexity="simple")
+    gwf = flopy.mf6.ModflowGwf(sim, modelname="pre", save_flows=True)
+    flopy.mf6.ModflowGwfdis(
+        gwf, nlay=1, nrow=1, ncol=10, delr=100.0, delc=100.0, top=10.0, botm=0.0
+    )
+    flopy.mf6.ModflowGwfic(gwf, strt=10.0)
+    flopy.mf6.ModflowGwfnpf(gwf, icelltype=0, k=10.0)
+    flopy.mf6.ModflowGwfsto(gwf, iconvert=0, ss=1.0e-5, transient={0: True})
+    flopy.mf6.ModflowGwfdrn(
+        gwf, stress_period_data=[[(0, 0, 0), 5.0, 1000.0]], pname="drn-1"
+    )
+    flopy.mf6.ModflowGwfchd(gwf, stress_period_data=[[(0, 0, 9), 10.0]], pname="chd-1")
+    flopy.mf6.ModflowGwfoc(gwf, head_filerecord="pre.hds", saverecord=[("HEAD", "ALL")])
+    sim.write_simulation(silent=True)
+    success, buff = sim.run_simulation(silent=True)
+    assert success, "\n".join(buff[-20:])
+
+    with open(ws / "pm.dat", "w") as f:
+        f.write("begin performance_measure obs\n")
+        f.write("  1 2 1 1 4 head direct 1.0 -1.0e+30\n")
+        f.write("end performance_measure\n")
+    return ws
+
+
+def _solve(ws, monkeypatch, break_the_factorization):
+    """Solve the adjoint, optionally with a factorization that cannot form."""
+    seen = {}
+    setup = PerfMeas._setup_jacobi_preconditioner
+
+    def spy(self, amat, jacobi_type="point", precon_kwargs=None):
+        seen["jacobi_type"] = jacobi_type
+        return setup(self, amat, jacobi_type, precon_kwargs)
+
+    monkeypatch.setattr(PerfMeas, "_setup_jacobi_preconditioner", spy)
+    if break_the_factorization:
+
+        def refuse(*args, **kwargs):
+            raise RuntimeError("Factor is exactly singular")
+
+        monkeypatch.setattr(mf6adj.pm, "spilu", refuse)
+
+    adj = mf6adj.Mf6Adj(
+        "pm.dat", lib_name, logging_level="WARNING", working_directory=str(ws)
+    )
+    adj.solve_forward_model(hdf5_name="fwd.hd5")
+    adj._performance_measures[0].solve_adjoint(
+        ws / "fwd.hd5",
+        hdf5_adjoint_solution_fname=str(ws / "adj.hd5"),
+        linear_solver="bicgstab",
+        dvclose=None,
+        rclose=None,
+    )
+    adj.finalize()
+    return seen
+
+
+def test_a_block_holds_the_whole_matrix():
+    """A matrix with fewer rows than a block is one block."""
+
+    class Shim:
+        logger = type("L", (), {"logger": __import__("logging").getLogger("pre")})()
+
+    amat = _matrix(50)
+    m = PerfMeas._setup_block_jacobi_preconditioner(Shim(), amat, block_size=BLOCK_SIZE)
+
+    # the preconditioner still solves, which a block of the wrong size
+    # would not, and on a matrix this size it is the whole factorization
+    v = np.ones(50)
+    assert np.isfinite(m @ v).all(), "a block larger than the matrix carries no solve"
+    assert BLOCK_SIZE > 50, "the block size no longer exceeds the matrix tested"
+
+
+def test_the_fallback_is_point(function_tmpdir, monkeypatch):
+    """A factorization that cannot be formed falls back on the point form.
+
+    Measured over the CONUS models, the block form cuts the iterations and
+    loses the time it saved to the block solves.
+    """
+    ws = _forward_file(function_tmpdir / "run")
+    seen = _solve(ws, monkeypatch, break_the_factorization=True)
+    assert seen.get("jacobi_type") == "point", (
+        f"the fallback used {seen.get('jacobi_type')!r} rather than the point form"
+    )
+
+
+def test_the_fallback_solves(function_tmpdir, monkeypatch):
+    """The solve that falls back still reaches an answer."""
+    ws = _forward_file(function_tmpdir / "run")
+    _solve(ws, monkeypatch, break_the_factorization=True)
+
+    import h5py
+
+    with h5py.File(ws / "adj.hd5", "r") as f:
+        keys = sorted(k for k in f if k.startswith("solution_kper"))
+        assert keys, "the fallback solve wrote no step"
+        state = np.asarray(f[keys[-1]]["lambda"][:])
+    assert np.isfinite(state).all(), "the fallback solve returned no number"
+    assert np.abs(state).max() > 0.0, "the fallback solve returned nothing"

--- a/mf6adj/pm.py
+++ b/mf6adj/pm.py
@@ -42,6 +42,13 @@ from .utils.utils_modflow import (
 
 PathLike = Union[str, pl.Path]
 
+# rows to a block of the block Jacobi preconditioner. Measured over the CONUS
+# models, a block of this size solves in two thirds the time one of 5,000
+# does, and one of 40,000 does not converge at all on the model whose full
+# factorization is singular: a block that grows toward the whole matrix
+# carries the same failure into the preconditioner
+BLOCK_SIZE = 20000
+
 
 class AdjointSolveError(Exception):
     """An adjoint solve that returned values which are not numbers."""
@@ -304,7 +311,7 @@ class PerfMeas:
             return 0.0
         return float(sum(dt_dict[kk] * val for kk, val in per_step.items()) / wsum)
 
-    def _setup_block_jacobi_preconditioner(self, amat, block_size=5000):
+    def _setup_block_jacobi_preconditioner(self, amat, block_size=BLOCK_SIZE):
         """Setup a block Jacobi preconditioner
 
         Parameters
@@ -312,7 +319,8 @@ class PerfMeas:
         amat : scipy.sparse.spmatrix
             Sparse matrix for which to create the block Jacobi preconditioner.
         block_size : int
-            Size of the blocks for the block Jacobi preconditioner.
+            Size of the blocks for the block Jacobi preconditioner. A matrix
+            with fewer rows than this is one block.
 
         Returns
         -------
@@ -321,6 +329,7 @@ class PerfMeas:
 
         """
         n = amat.shape[0]
+        block_size = min(int(block_size), n)
         self.logger.logger.debug(
             f"Setup block Jacobi preconditioner with {block_size:,} block size "
             + f"for matrix with {n:,} rows"
@@ -1029,9 +1038,14 @@ class PerfMeas:
                             else:
                                 _linear_solver_kwargs["maxiter"] = 10000
 
+                            # point rather than block. Measured on the
+                            # models this falls back on, block Jacobi cuts
+                            # the iterations and loses the time it saved to
+                            # the block solves, taking two to three times as
+                            # long overall
                             m = self._setup_jacobi_preconditioner(
                                 amat,
-                                jacobi_type="block",
+                                jacobi_type="point",
                                 precon_kwargs=_precon_kwargs,
                             )
 

--- a/mf6adj/pm.py
+++ b/mf6adj/pm.py
@@ -49,6 +49,12 @@ PathLike = Union[str, pl.Path]
 # carries the same failure into the preconditioner
 BLOCK_SIZE = 20000
 
+# rows to a block above which the preconditioner is reported. A block of
+# 40,000 did not converge on the CONUS model whose full factorization is
+# singular, a block growing toward the whole matrix carrying that failure
+# into the preconditioner
+BLOCK_SIZE_LIMIT = 40000
+
 
 class AdjointSolveError(Exception):
     """An adjoint solve that returned values which are not numbers."""
@@ -330,6 +336,15 @@ class PerfMeas:
         """
         n = amat.shape[0]
         block_size = min(int(block_size), n)
+        if block_size > BLOCK_SIZE_LIMIT:
+            self.logger.logger.warning(
+                f"the block Jacobi preconditioner holds {block_size:,} rows to "
+                + f"a block, above the {BLOCK_SIZE_LIMIT:,} a block was "
+                + "measured to solve at. A block growing toward the whole "
+                + "matrix carries the failure of the whole factorization into "
+                + "the preconditioner, and a solve that does not converge is "
+                + "what that looks like."
+            )
         self.logger.logger.debug(
             f"Setup block Jacobi preconditioner with {block_size:,} block size "
             + f"for matrix with {n:,} rows"
@@ -1019,9 +1034,9 @@ class PerfMeas:
                         except Exception as e:
                             msg = (
                                 "Failed to form preconditioner - "
-                                + f"using Jacobi preconditioned {linear_solver} "
-                                + "solver and reset maxiter to "
-                                + f"{_linear_solver_kwargs['maxiter']}"
+                                + "using point Jacobi preconditioned "
+                                + f"{linear_solver} solver and reset maxiter "
+                                + f"to {_linear_solver_kwargs['maxiter']}"
                             )
                             self.logger.logger.info(msg)
 


### PR DESCRIPTION
The incomplete factorization the adjoint is preconditioned with cannot be formed on every model, and what it falls back on was the block Jacobi form. Measured over four CONUS models with the adjoint matrix and right side of a real run, that is the slowest of the choices available.

| model | rows | ilu | point jacobi | block 5000 | block 20000 |
| --- | --- | --- | --- | --- | --- |
| 1601 | 311k | 0.6s / 1 | **0.4s / 115** | 1.1s / 33 | 0.9s / 21 |
| 1708_1711_1713 | 1.06M | 2.2s / 1 | **0.5s / 76** | 2.7s / 29 | 2.7s / 19 |
| 0511_0513_0514 | 1.65M | 4.4s / 1 | **0.9s / 82** | 6.1s / 44 | 4.6s / 24 |
| 1504_1505_1508 | 1.54M | cannot be formed | **20.5s / 1,960** | 55.9s / 502 | 31.5s / 231 |

The block form does cut the iterations, three to eight times, and loses more than it saved to the block solves. Two of the five models measured take the fallback, so this is a third of the adjoint time on those. Every choice agrees with every other to 1.1e-06 of the largest state, so this is a question of time and not of the answer.

The rows to a block are raised from 5,000 to 20,000 for a caller who asks for the block form. It is not raised further:

| block size | 1504_1505_1508 | 0511_0513_0514 |
| --- | --- | --- |
| 5,000 | 53.1s / 502 | 7.6s / 44 |
| 10,000 | 41.3s / 322 | 6.6s / 34 |
| 20,000 | **31.3s / 231** | **5.0s / 24** |
| 40,000 | 1361.8s / 10,000 | 5.1s / 20 |
| 80,000 | 951.7s / 6,861 | 6.0s / 22 |

A block of 40,000 does not converge on 1504_1505_1508, which is the model whose full factorization is singular: a block growing toward the whole matrix carries that failure into the preconditioner. Setting the size from the bandwidth after the reordering was tried and does not work, the reordering leaving two of the four models with a bandwidth the size of the matrix.

A matrix with fewer rows than a block is one block, which the reported size now says rather than reporting a size larger than the matrix.
