### PR TITLE
docs(readme): build the quick start measure with the writer

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,11 +43,21 @@ mf6_bin, lib_name = mf6adj.get_conda_mf6_paths()
 # run the baseline forward model
 flopy.run_model(exe_name=mf6_bin, namefile=None, model_ws="path/to/model")
 
-# write a performance-measure file
-with open("path/to/model/model.adj", "w") as f:
-    f.write("begin performance_measure head_obs\n")
-    f.write("1 1 1 5 5 head direct 1.0 -1.0e+30\n")
-    f.write("end performance_measure\n")
+# write a performance-measure file, with the cell zero based as flopy gives it
+mf6adj.write_performance_measures(
+    "path/to/model/model.adj",
+    {
+        "head_obs": {
+            "cellid": [(0, 4, 4)],
+            "kper": 0,
+            "kstp": 0,
+            "pm_type": "head",
+            "pm_form": "direct",
+            "weight": 1.0,
+            "obsval": -1.0e30,
+        }
+    },
+)
 
 # solve forward and adjoint
 adj = mf6adj.Mf6Adj("model.adj", str(lib_name), working_directory="path/to/model")


### PR DESCRIPTION
The quick start wrote a performance measure by hand, which `usage.rst` tells a reader not to do and which the example notebooks stopped doing in #154. It was the last place in the repository that formatted the lines itself, and it is the first code a reader sees. `README.md` is also the long description built for PyPI, so this block is the quick start the project page renders.

The measure is unchanged. The writer emits the same entry, and the file it produces reads back equal to the one written by hand:

```
begin performance_measure head_obs
  1 1 1 5 5 head direct 1.0 -1e+30
end performance_measure
```

The cell is given zero based, as flopy gives it, rather than one based as the file wants.

Closes #156
